### PR TITLE
feat: emit z.string().datetime() for date/time scalars

### DIFF
--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -435,10 +435,13 @@ function generateScalarSchema(scalar: Scalar): string {
 		case "boolean":
 			return "z.boolean()";
 		case "plainDate":
+			return "z.string().date()";
 		case "plainTime":
+			return "z.string().time()";
 		case "utcDateTime":
+			return "z.string().datetime()";
 		case "offsetDateTime":
-			return "z.date()";
+			return "z.string().datetime({ offset: true })";
 		case "duration":
 			return "z.string()";
 		case "url":

--- a/test/example.js
+++ b/test/example.js
@@ -73,7 +73,7 @@ try {
 		tags: ["typespec", "api", "tutorial"],
 		metadata: { category: "tutorial", difficulty: "beginner" },
 		published: true,
-		createdAt: new Date(),
+		createdAt: new Date().toISOString(),
 	};
 	const _result = PostSchema.parse(validPost);
 	console.log("✓ Valid post created");


### PR DESCRIPTION
## Summary
- Emit `z.string().datetime()` instead of `z.date()` for `utcDateTime` scalars, so Zod correctly validates ISO 8601 strings in JSON/REST responses
- Map `plainDate` → `z.string().date()`, `plainTime` → `z.string().time()`, `offsetDateTime` → `z.string().datetime({ offset: true })`
- Update test example to use ISO string instead of `Date` object

Closes #12

## Test plan
- [x] `npm run build` compiles without errors
- [x] `npm run test:emit` generates schemas with `z.string().datetime()`
- [x] `npm run test:example` passes with ISO string input

🤖 Generated with [Claude Code](https://claude.com/claude-code)