### PR TITLE
Add unit tests and expand smoke coverage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,20 @@
 {
-	"name": "typespec-zod-emitter",
+	"name": "@kattebak/typespec-zod-emitter",
 	"version": "1.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "typespec-zod-emitter",
+			"name": "@kattebak/typespec-zod-emitter",
 			"version": "1.0.0",
 			"dependencies": {
 				"@typespec/compiler": "^1.4.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^2.3.7",
-				"typescript": "^5.9.3"
+				"tsx": "^4.20.5",
+				"typescript": "^5.9.3",
+				"zod": "^3.0.0"
 			},
 			"peerDependencies": {
 				"zod": "^3.0.0"
@@ -202,6 +204,448 @@
 			],
 			"engines": {
 				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+			"integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+			"integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+			"integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+			"integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+			"integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+			"integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+			"integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+			"integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+			"integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+			"integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+			"integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+			"integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+			"integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+			"integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+			"integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+			"integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+			"integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+			"integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+			"integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+			"integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+			"integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+			"integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+			"integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+			"integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+			"integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+			"integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@inquirer/ansi": {
@@ -840,6 +1284,48 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/esbuild": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+			"integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.27.3",
+				"@esbuild/android-arm": "0.27.3",
+				"@esbuild/android-arm64": "0.27.3",
+				"@esbuild/android-x64": "0.27.3",
+				"@esbuild/darwin-arm64": "0.27.3",
+				"@esbuild/darwin-x64": "0.27.3",
+				"@esbuild/freebsd-arm64": "0.27.3",
+				"@esbuild/freebsd-x64": "0.27.3",
+				"@esbuild/linux-arm": "0.27.3",
+				"@esbuild/linux-arm64": "0.27.3",
+				"@esbuild/linux-ia32": "0.27.3",
+				"@esbuild/linux-loong64": "0.27.3",
+				"@esbuild/linux-mips64el": "0.27.3",
+				"@esbuild/linux-ppc64": "0.27.3",
+				"@esbuild/linux-riscv64": "0.27.3",
+				"@esbuild/linux-s390x": "0.27.3",
+				"@esbuild/linux-x64": "0.27.3",
+				"@esbuild/netbsd-arm64": "0.27.3",
+				"@esbuild/netbsd-x64": "0.27.3",
+				"@esbuild/openbsd-arm64": "0.27.3",
+				"@esbuild/openbsd-x64": "0.27.3",
+				"@esbuild/openharmony-arm64": "0.27.3",
+				"@esbuild/sunos-x64": "0.27.3",
+				"@esbuild/win32-arm64": "0.27.3",
+				"@esbuild/win32-ia32": "0.27.3",
+				"@esbuild/win32-x64": "0.27.3"
+			}
+		},
 		"node_modules/escalade": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -908,6 +1394,21 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
 		"node_modules/get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -927,6 +1428,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/get-tsconfig": {
+			"version": "4.13.6",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+			"integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"resolve-pkg-maps": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
 			}
 		},
 		"node_modules/glob-parent": {
@@ -1184,6 +1698,16 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/resolve-pkg-maps": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+			}
+		},
 		"node_modules/reusify": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -1326,6 +1850,26 @@
 			},
 			"engines": {
 				"node": ">=8.0"
+			}
+		},
+		"node_modules/tsx": {
+			"version": "4.21.0",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+			"integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "~0.27.0",
+				"get-tsconfig": "^4.7.5"
+			},
+			"bin": {
+				"tsx": "dist/cli.mjs"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
 			}
 		},
 		"node_modules/typescript": {
@@ -1533,8 +2077,8 @@
 			"version": "3.25.76",
 			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
 			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/package.json
+++ b/package.json
@@ -23,16 +23,19 @@
 		"lint": "npx @biomejs/biome check",
 		"build": "tsc",
 		"watch": "tsc --watch",
-		"test": "npm run build && npm run lint && npm run test:emit && npm run test:example",
+		"test": "npm run build && npm run lint && npm run test:unit && npm run test:emit && npm run test:example",
 		"test:emit": "tsp compile test/main.tsp --config test/tspconfig.yaml",
-		"test:example": "node test/example.js"
+		"test:example": "npm run test:emit && node --test test/example.js",
+		"test:unit": "node --test --import=tsx src/**/*.test.ts"
 	},
 	"dependencies": {
 		"@typespec/compiler": "^1.4.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.3.7",
-		"typescript": "^5.9.3"
+		"tsx": "^4.20.5",
+		"typescript": "^5.9.3",
+		"zod": "^3.0.0"
 	},
 	"peerDependencies": {
 		"zod": "^3.0.0"

--- a/src/emitter.test.ts
+++ b/src/emitter.test.ts
@@ -1,0 +1,203 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import type {
+	Enum,
+	Model,
+	ModelProperty,
+	Scalar,
+	Type,
+	Union,
+} from "@typespec/compiler";
+import { __test } from "./emitter.js";
+
+type ModelLike = Model & { kind: "Model" };
+
+describe("emitter helpers", () => {
+	it("validates identifiers and quotes invalid names", () => {
+		assert.equal(__test.isValidJavaScriptIdentifier("validName"), true);
+		assert.equal(__test.isValidJavaScriptIdentifier("_valid"), true);
+		assert.equal(__test.isValidJavaScriptIdentifier("kebab-case"), false);
+		assert.equal(__test.isValidJavaScriptIdentifier("123name"), false);
+		assert.equal(__test.isValidJavaScriptIdentifier("class"), false);
+
+		assert.equal(__test.quotePropertyName("validName"), "validName");
+		assert.equal(__test.quotePropertyName("kebab-case"), '"kebab-case"');
+		assert.equal(__test.quotePropertyName("class"), '"class"');
+	});
+
+	it("generates enum schemas", () => {
+		const emptyEnum = {
+			name: "Empty",
+			members: new Map(),
+		} as unknown as Enum;
+
+		const mixedEnum = {
+			name: "Status",
+			members: new Map([
+				["Active", { name: "Active" }],
+				["Low", { name: "Low", value: "low" }],
+				["One", { name: "One", value: 1 }],
+			]),
+		} as unknown as Enum;
+
+		assert.equal(
+			__test.generateEnumSchema(emptyEnum),
+			"export const EmptySchema = z.never();",
+		);
+		assert.equal(
+			__test.generateEnumSchema(mixedEnum),
+			'export const StatusSchema = z.enum(["Active", "low", 1]);',
+		);
+	});
+
+	it("generates scalar schemas", () => {
+		const stringScalar = { name: "string" } as unknown as Scalar;
+		const intScalar = { name: "int32" } as unknown as Scalar;
+		const utcScalar = { name: "utcDateTime" } as unknown as Scalar;
+		const urlScalar = { name: "url" } as unknown as Scalar;
+		const bytesScalar = { name: "bytes" } as unknown as Scalar;
+
+		assert.equal(__test.generateScalarSchema(stringScalar), "z.string()");
+		assert.equal(__test.generateScalarSchema(intScalar), "z.number()");
+		assert.equal(
+			__test.generateScalarSchema(utcScalar),
+			"z.string().datetime()",
+		);
+		assert.equal(__test.generateScalarSchema(urlScalar), "z.string().url()");
+		assert.equal(
+			__test.generateScalarSchema(bytesScalar),
+			"z.instanceof(Uint8Array)",
+		);
+	});
+
+	it("generates union schemas", () => {
+		const emptyUnion = { variants: new Map() } as unknown as Union;
+		const singleUnion = {
+			variants: new Map([["a", { type: { kind: "String", value: "a" } }]]),
+		} as unknown as Union;
+		const multiUnion = {
+			variants: new Map([
+				["a", { type: { kind: "String", value: "a" } }],
+				["b", { type: { kind: "String", value: "b" } }],
+			]),
+		} as unknown as Union;
+
+		assert.equal(__test.generateUnionSchema(emptyUnion), "z.never()");
+		assert.equal(__test.generateUnionSchema(singleUnion), 'z.literal("a")');
+		assert.equal(
+			__test.generateUnionSchema(multiUnion),
+			'z.union([z.literal("a"), z.literal("b")])',
+		);
+	});
+
+	it("orders models and emits schemas", () => {
+		const stringScalar = { kind: "Scalar", name: "string" } as Scalar;
+		const modelB: ModelLike = {
+			kind: "Model",
+			name: "B",
+			properties: new Map(),
+		} as ModelLike;
+
+		const modelA: ModelLike = {
+			kind: "Model",
+			name: "A",
+			properties: new Map([
+				[
+					"child",
+					{ type: modelB, optional: false } as unknown as ModelProperty,
+				],
+				[
+					"label",
+					{ type: stringScalar, optional: false } as unknown as ModelProperty,
+				],
+			]),
+		} as ModelLike;
+
+		const models = [modelA, modelB];
+		const modelNameMap = new Map<Model, string>([
+			[modelA, "A"],
+			[modelB, "B"],
+		]);
+
+		const content = __test.generateZodSchemas(
+			models,
+			[],
+			"unit-tests",
+			"1.0.0",
+			modelNameMap,
+		);
+
+		const indexOfB = content.indexOf("export const BSchema");
+		const indexOfA = content.indexOf("export const ASchema");
+
+		assert.equal(content.includes('import { z } from "zod";'), true);
+		assert.equal(content.includes("Package: unit-tests"), true);
+		assert.equal(indexOfB < indexOfA, true);
+		assert.equal(content.includes("child: BSchema"), true);
+	});
+
+	it("renders array and record models", () => {
+		const stringScalar = { kind: "Scalar", name: "string" } as Scalar;
+		const arrayModel = {
+			kind: "Model",
+			name: "Array",
+			indexer: { value: stringScalar },
+		} as unknown as Model;
+		const recordModel = {
+			kind: "Model",
+			name: "Record",
+			indexer: { key: { name: "string" }, value: stringScalar },
+		} as unknown as Model;
+
+		assert.equal(
+			__test.generateModelTypeSchema(arrayModel),
+			"z.array(z.string())",
+		);
+		assert.equal(
+			__test.generateModelTypeSchema(recordModel),
+			"z.record(z.string(), z.string())",
+		);
+	});
+
+	it("renders anonymous object models", () => {
+		const stringScalar = { kind: "Scalar", name: "string" } as Scalar;
+		const anonymousModel = {
+			kind: "Model",
+			name: "",
+			properties: new Map([
+				[
+					"kebab-case",
+					{ type: stringScalar, optional: false } as unknown as ModelProperty,
+				],
+			]),
+		} as unknown as Model;
+
+		assert.equal(
+			__test.generateModelTypeSchema(anonymousModel),
+			'z.object({ "kebab-case": z.string() })',
+		);
+	});
+
+	it("detects template declarations", () => {
+		const templateModel = {
+			kind: "Model",
+			name: "ResultList",
+			properties: new Map([
+				[
+					"items",
+					{
+						type: {
+							kind: "Model",
+							name: "Array",
+							indexer: { value: { kind: "TemplateParameter" } },
+						} as Type,
+						optional: false,
+					} as unknown as ModelProperty,
+				],
+			]),
+		} as unknown as Model;
+
+		assert.equal(__test.isTemplateDeclaration(templateModel), true);
+	});
+});

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -627,3 +627,20 @@ node_modules/
 .DS_Store
 `;
 }
+
+export const __test = {
+	containsTemplateParameter,
+	generateEnumSchema,
+	generateModelSchema,
+	generateModelTypeSchema,
+	generatePropertySchema,
+	generateScalarSchema,
+	generateTypeSchema,
+	generateUnionSchema,
+	generateZodSchemas,
+	getModelDependencies,
+	isTemplateDeclaration,
+	isValidJavaScriptIdentifier,
+	quotePropertyName,
+	topologicalSort,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./emitter.js";
+export { $onEmit } from "./emitter.js";
 export { $lib } from "./lib.js";

--- a/test/example.js
+++ b/test/example.js
@@ -1,118 +1,277 @@
-import {
-	PostSchema,
-	ProfileSchema,
-	UserSchema,
-} from "../build/zod-schemas/schemas.ts";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
 
-console.log("=== Zod Validation Examples ===\n");
+import * as Schemas from "../build/zod-schemas/schemas.ts";
 
-console.log("1. Valid User:");
-try {
-	const validUser = {
-		id: "123",
-		name: "John Doe",
-		email: "john@example.com",
-		age: 30,
-		isActive: true,
-		status: "Active",
-		priority: "high",
-	};
-	const result = UserSchema.parse(validUser);
-	console.log("✓ Valid:", JSON.stringify(result, null, 2));
-} catch (error) {
-	console.log("✗ Error:", error.message);
-}
+describe("zod schema smoke tests", () => {
+	it("parses a valid user", () => {
+		const validUser = {
+			id: "123",
+			name: "John Doe",
+			email: "john@example.com",
+			age: 30,
+			isActive: true,
+			status: "Active",
+			priority: "high",
+		};
 
-console.log("\n2. Invalid User (missing required field):");
-try {
-	const invalidUser = {
-		id: "123",
-		name: "Jane Doe",
-		isActive: true,
-		status: "Active",
-		priority: "low",
-	};
-	UserSchema.parse(invalidUser);
-} catch (error) {
-	console.log(
-		"✗ Validation failed:",
-		error.errors[0].message,
-		"at",
-		error.errors[0].path.join("."),
-	);
-}
+		const result = Schemas.UserSchema.parse(validUser);
 
-console.log("\n3. Invalid User (wrong type):");
-try {
-	const invalidUser = {
-		id: "123",
-		name: "Jane Doe",
-		email: "jane@example.com",
-		age: "thirty",
-		isActive: true,
-		status: "Active",
-		priority: "low",
-	};
-	UserSchema.parse(invalidUser);
-} catch (error) {
-	console.log(
-		"✗ Validation failed:",
-		error.errors[0].message,
-		"at",
-		error.errors[0].path.join("."),
-	);
-}
+		assert.equal(result.id, "123");
+		assert.equal(result.email, "john@example.com");
+	});
 
-console.log("\n4. Valid Post with arrays and metadata:");
-try {
-	const validPost = {
-		id: "post-1",
-		title: "Introduction to TypeSpec",
-		content: "TypeSpec is a language for defining APIs...",
-		authorId: "123",
-		tags: ["typespec", "api", "tutorial"],
-		metadata: { category: "tutorial", difficulty: "beginner" },
-		published: true,
-		createdAt: new Date().toISOString(),
-	};
-	const _result = PostSchema.parse(validPost);
-	console.log("✓ Valid post created");
-} catch (error) {
-	console.log("✗ Error:", error.message);
-}
+	it("rejects a user missing required fields", () => {
+		const invalidUser = {
+			id: "123",
+			name: "Jane Doe",
+			isActive: true,
+			status: "Active",
+			priority: "low",
+		};
 
-console.log("\n5. Optional fields in Profile:");
-try {
-	const minimalProfile = {
-		userId: "123",
-		address: {
-			street: "123 Main St",
-			city: "Springfield",
-			zipCode: "12345",
-			country: "USA",
-		},
-		socialLinks: ["https://twitter.com/johndoe"],
-	};
-	const _result = ProfileSchema.parse(minimalProfile);
-	console.log("✓ Valid profile (optional fields omitted)");
-} catch (error) {
-	console.log("✗ Error:", error.message);
-}
+		assert.throws(() => Schemas.UserSchema.parse(invalidUser));
+	});
 
-console.log("\n6. Type inference:");
-const user = UserSchema.parse({
-	id: "123",
-	name: "John Doe",
-	email: "john@example.com",
-	isActive: true,
-	status: "Active",
-	priority: "high",
+	it("rejects a user with wrong types", () => {
+		const invalidUser = {
+			id: "123",
+			name: "Jane Doe",
+			email: "jane@example.com",
+			age: "thirty",
+			isActive: true,
+			status: "Active",
+			priority: "low",
+		};
+
+		assert.throws(() => Schemas.UserSchema.parse(invalidUser));
+	});
+
+	it("parses a valid post with arrays and metadata", () => {
+		const validPost = {
+			id: "post-1",
+			title: "Introduction to TypeSpec",
+			content: "TypeSpec is a language for defining APIs...",
+			authorId: "123",
+			tags: ["typespec", "api", "tutorial"],
+			metadata: { category: "tutorial", difficulty: "beginner" },
+			published: true,
+			createdAt: new Date().toISOString(),
+		};
+
+		const result = Schemas.PostSchema.parse(validPost);
+
+		assert.equal(result.id, "post-1");
+		assert.equal(result.metadata.category, "tutorial");
+	});
+
+	it("parses a minimal profile with optional fields omitted", () => {
+		const minimalProfile = {
+			userId: "123",
+			address: {
+				street: "123 Main St",
+				city: "Springfield",
+				zipCode: "12345",
+				country: "USA",
+			},
+			socialLinks: ["https://twitter.com/johndoe"],
+		};
+
+		const result = Schemas.ProfileSchema.parse(minimalProfile);
+
+		assert.equal(result.userId, "123");
+		assert.equal(result.address.city, "Springfield");
+	});
+
+	it("validates enum values", () => {
+		assert.equal(Schemas.StatusSchema.parse("Active"), "Active");
+		assert.equal(Schemas.PrioritySchema.parse("low"), "low");
+		assert.throws(() => Schemas.StatusSchema.parse("Unknown"));
+	});
+
+	it("parses user list derived from generic template", () => {
+		const userList = {
+			continuationToken: "next",
+			items: [
+				{
+					id: "123",
+					name: "John Doe",
+					email: "john@example.com",
+					isActive: true,
+					status: "Active",
+					priority: "high",
+				},
+			],
+		};
+
+		const result = Schemas.UserListSchema.parse(userList);
+		assert.equal(result.items.length, 1);
+		assert.equal(result.items[0].id, "123");
+	});
+
+	it("parses lifecycle create params", () => {
+		const createPayload = {
+			name: "Widget",
+			price: 19.99,
+			inStock: true,
+			attributes: [
+				{
+					key: "color",
+					value: "red",
+				},
+			],
+			productId: "ignore-me",
+			createdAt: 1700000000,
+		};
+
+		const result = Schemas.ProductCreateParamsSchema.parse(createPayload);
+		assert.equal(result.attributes[0].key, "color");
+		assert.equal("productId" in result, false);
+		assert.equal("createdAt" in result, false);
+	});
+
+	it("parses lifecycle update params", () => {
+		const updatePayload = {
+			name: "Updated Widget",
+		};
+
+		const result = Schemas.ProductUpdateParamsSchema.parse(updatePayload);
+		assert.deepEqual(result, {});
+	});
+
+	it("parses full product schema", () => {
+		const product = {
+			productId: "product-1",
+			name: "Widget",
+			price: 19.99,
+			inStock: true,
+			attributes: [
+				{
+					attributeId: "attr-1",
+					productId: "product-1",
+					key: "color",
+					value: "red",
+				},
+			],
+			createdAt: 1700000000,
+			updatedAt: 1700001000,
+		};
+
+		const result = Schemas.ProductSchema.parse(product);
+		assert.equal(result.productId, "product-1");
+		assert.equal(result.attributes[0].attributeId, "attr-1");
+	});
+
+	it("parses product attribute create params", () => {
+		const createPayload = {
+			key: "size",
+			value: "large",
+			attributeId: "ignore-me",
+			productId: "ignore-me",
+		};
+
+		const result =
+			Schemas.ProductAttributeCreateParamsSchema.parse(createPayload);
+		assert.equal(result.key, "size");
+		assert.equal("attributeId" in result, false);
+		assert.equal("productId" in result, false);
+	});
+
+	it("parses product attribute update params", () => {
+		const updatePayload = {
+			value: "large",
+			attributeId: "ignore-me",
+			productId: "ignore-me",
+		};
+
+		const result =
+			Schemas.ProductAttributeUpdateParamsSchema.parse(updatePayload);
+		assert.equal("attributeId" in result, false);
+		assert.equal("productId" in result, false);
+		if ("value" in result) {
+			assert.equal(result.value, "large");
+		}
+	});
+
+	it("parses anonymous object fields", () => {
+		const upload = {
+			item: {
+				id: "item-1",
+				name: "Widget",
+			},
+			urls: {
+				s3: "https://s3.example.com/item-1",
+			},
+		};
+
+		const result = Schemas.ItemUploadSchema.parse(upload);
+		assert.equal(result.item.name, "Widget");
+		assert.equal(result.urls.s3, "https://s3.example.com/item-1");
+	});
+
+	it("parses complex anonymous objects", () => {
+		const complex = {
+			metadata: {
+				author: "Ada",
+				tags: ["release", "notes"],
+				settings: {
+					visibility: "public",
+					downloadable: true,
+				},
+			},
+		};
+
+		const result = Schemas.ComplexUploadSchema.parse(complex);
+		assert.equal(result.metadata.settings.visibility, "public");
+		assert.equal(result.metadata.tags.length, 2);
+	});
+
+	it("accepts empty anonymous object schema", () => {
+		const result = Schemas.EmptyObjectTestSchema.parse({ emptyData: {} });
+		assert.deepEqual(result.emptyData, {});
+	});
+
+	it("parses quoted and reserved identifiers", () => {
+		const invalidIdentifiers = {
+			"kebab-case": "value",
+			"with space": "value",
+			"123numeric": "value",
+			"special@char": "value",
+			normalKey: "value",
+		};
+
+		const reservedWords = {
+			class: "value",
+			const: "value",
+			return: "value",
+			function: "value",
+			normalProp: "value",
+		};
+
+		const invalidIdentifiersResult =
+			Schemas.InvalidIdentifiersSchema.parse(invalidIdentifiers);
+		const reservedWordsResult =
+			Schemas.ReservedWordsSchema.parse(reservedWords);
+
+		assert.equal(invalidIdentifiersResult["kebab-case"], "value");
+		assert.equal(reservedWordsResult.class, "value");
+	});
+
+	it("parses invalid identifiers inside anonymous objects", () => {
+		const payload = {
+			data: {
+				"kebab-case": "value",
+				"another-kebab": 42,
+				validKey: true,
+			},
+		};
+
+		const result = Schemas.AnonymousWithInvalidKeysSchema.parse(payload);
+		assert.equal(result.data["another-kebab"], 42);
+		assert.equal(result.data.validKey, true);
+	});
+
+	it("does not emit generic template schemas", () => {
+		assert.equal("ResultListSchema" in Schemas, false);
+	});
 });
-console.log(
-	"✓ TypeScript will infer the type:",
-	typeof user,
-	"with properties:",
-	Object.keys(user).join(", "),
-);
-
-console.log("\n=== All tests completed ===");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
 		"esModuleInterop": true
 	},
 	"include": ["src/**/*"],
-	"exclude": ["node_modules", "dist"]
+	"exclude": ["node_modules", "dist", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
- add unit tests for emitter helpers and expose test utilities
- expand smoke tests for lifecycle models and product attributes
- wire unit test runner and ensure test schemas are regenerated
- tighten public exports and exclude test files from build

## Testing
- npm test
