### PR TITLE
fix!: add prepare script to generated package.json

### DIFF
--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -540,8 +540,14 @@ function generatePackageJson(
 				default: "./schemas.js",
 			},
 		},
+		scripts: {
+			prepare: "tsc",
+		},
 		peerDependencies: {
 			zod: "^3.0.0",
+		},
+		devDependencies: {
+			typescript: "^5.0.0",
 		},
 	};
 


### PR DESCRIPTION
## Summary
- Adds a `prepare` script (`tsc`) to the generated `package.json` so workspace consumers get compiled `.js` and `.d.ts` output automatically after `npm install`
- Adds `typescript` as a `devDependency` in the generated package so `tsc` is available

Closes #17

## Test plan
- [x] All existing unit and smoke tests pass
- [x] Verified the generated `package.json` includes the new `scripts.prepare` and `devDependencies.typescript` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)