### PR TITLE
fix: add prepublishOnly script to ensure dist/ is built before publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
 		"test": "npm run build && npm run lint && npm run test:unit && npm run test:emit && npm run test:example",
 		"test:emit": "tsp compile test/main.tsp --config test/tspconfig.yaml",
 		"test:example": "npm run test:emit && node --test test/example.js",
-		"test:unit": "node --test --import=tsx src/**/*.test.ts"
+		"test:unit": "node --test --import=tsx src/**/*.test.ts",
+		"prepublishOnly": "tsc"
 	},
 	"dependencies": {
 		"@typespec/compiler": "^1.4.0"


### PR DESCRIPTION
## Summary
- Adds `"prepublishOnly": "tsc"` script to `package.json` so `dist/` is always compiled before `npm publish`
- Prevents the issue where v2.0.0 shipped without any `dist/` files, making the package non-functional

Closes #24

## Test plan
- [x] `npm run build` succeeds
- [x] All unit tests pass (38/38)
- [x] All smoke tests pass (18/18)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)