### PR TITLE
ci: publish via npm trusted publishing

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -41,7 +41,7 @@ jobs:
       contents: write # to be able to publish a GitHub release
       issues: write # to be able to comment on released issues
       pull-requests: write # to be able to comment on released pull requests
-      # id-token: write # to enable use of OIDC for npm provenance
+      id-token: write # to enable use of OIDC for npm provenance
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js
@@ -53,5 +53,4 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
## Summary
Switches the publish job to npm trusted publishing (OIDC) instead of an `NPM_TOKEN` secret.

- Enables `id-token: write` on the publish job.
- Drops the `NPM_TOKEN` env var; `GITHUB_TOKEN` remains for the GitHub release/PR/issue comments.

Trusted publishing requires npm CLI >= 11.5.1 and `@semantic-release/npm` >= 12.0.2. `node-version: "lts/*"` already bundles npm 11.13+, and `npx semantic-release` resolves latest semantic-release (25.x), which depends on `@semantic-release/npm` ^13.1.1 — both prerequisites are already satisfied, so no version pins were added.

## Test plan
- [x] CI (`ci` sentinel job)