### PR TITLE
fix: emit inherited properties from base models

### DIFF
--- a/src/emitter.test.ts
+++ b/src/emitter.test.ts
@@ -351,6 +351,58 @@ describe("emitter helpers", () => {
 		);
 	});
 
+	// === getAllProperties: base-model inheritance ===
+
+	it("collects inherited properties, subclass overriding on name collision", () => {
+		const stringScalar = { kind: "Scalar", name: "string" } as Scalar;
+		const intScalar = { kind: "Scalar", name: "int32" } as Scalar;
+		const literalStatus = { kind: "String", value: "goodBoy" } as Type;
+
+		const baseModel = {
+			kind: "Model",
+			name: "Animal",
+			properties: new Map([
+				[
+					"legs",
+					{ type: intScalar, optional: false } as unknown as ModelProperty,
+				],
+				[
+					"status",
+					{ type: stringScalar, optional: false } as unknown as ModelProperty,
+				],
+			]),
+		} as unknown as Model;
+
+		const model = {
+			kind: "Model",
+			name: "Dog",
+			baseModel,
+			properties: new Map([
+				[
+					"breed",
+					{ type: stringScalar, optional: false } as unknown as ModelProperty,
+				],
+				[
+					"status",
+					{ type: literalStatus, optional: false } as unknown as ModelProperty,
+				],
+			]),
+		} as unknown as Model;
+
+		const props = __test.getAllProperties(model);
+		assert.deepEqual(
+			[...props.keys()],
+			["legs", "status", "breed"],
+			"base properties come first, own properties appended/overridden in place",
+		);
+		assert.equal(props.get("status")?.type, literalStatus);
+
+		const result = __test.generateModelSchema(model);
+		assert.ok(result.includes("legs: z.number()"));
+		assert.ok(result.includes("breed: z.string()"));
+		assert.ok(result.includes('status: z.literal("goodBoy")'));
+	});
+
 	// === getModelDependencies ===
 
 	it("gets model dependencies including enum dependency", () => {

--- a/src/emitter.test.ts
+++ b/src/emitter.test.ts
@@ -422,6 +422,41 @@ describe("emitter helpers", () => {
 		assert.ok(deps.has("Status"));
 	});
 
+	it("gets model dependencies inherited from a base model", () => {
+		const targetModel = { kind: "Model", name: "Target" } as unknown as Model;
+		const stringScalar = { kind: "Scalar", name: "string" } as Scalar;
+
+		const baseModel = {
+			kind: "Model",
+			name: "Base",
+			properties: new Map([
+				[
+					"ref",
+					{ type: targetModel, optional: false } as unknown as ModelProperty,
+				],
+			]),
+		} as unknown as Model;
+
+		const subModel = {
+			kind: "Model",
+			name: "Sub",
+			baseModel,
+			properties: new Map([
+				[
+					"ownField",
+					{ type: stringScalar, optional: false } as unknown as ModelProperty,
+				],
+			]),
+		} as unknown as Model;
+
+		// Sub's own properties don't reference Target directly — only the
+		// inherited `ref` property does. If getModelDependencies only walked
+		// model.properties, this dependency would be missed and the
+		// topological sort could emit Sub's schema before Target's.
+		const deps = __test.getModelDependencies(subModel);
+		assert.ok(deps.has("Target"));
+	});
+
 	it("gets model dependencies from union containing model refs", () => {
 		const modelRef = {
 			kind: "Model",

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -352,13 +352,26 @@ function quotePropertyName(name: string): string {
 	return isValidJavaScriptIdentifier(name) ? name : `"${name}"`;
 }
 
+function getAllProperties(model: Model): Map<string, ModelProperty> {
+	const props = new Map<string, ModelProperty>();
+	if (model.baseModel) {
+		for (const [name, prop] of getAllProperties(model.baseModel)) {
+			props.set(name, prop);
+		}
+	}
+	for (const [name, prop] of model.properties) {
+		props.set(name, prop);
+	}
+	return props;
+}
+
 function generateModelSchema(
 	model: Model,
 	modelNameMap?: Map<Model, string>,
 ): string {
 	const properties: string[] = [];
 
-	for (const [propName, prop] of model.properties) {
+	for (const [propName, prop] of getAllProperties(model)) {
 		const zodType = generatePropertySchema(prop, modelNameMap);
 		const quotedName = quotePropertyName(propName);
 		properties.push(`\t${quotedName}: ${zodType}`);
@@ -644,6 +657,7 @@ export const __test = {
 	generateTypeSchema,
 	generateUnionSchema,
 	generateZodSchemas,
+	getAllProperties,
 	getModelDependencies,
 	isTemplateDeclaration,
 	isValidJavaScriptIdentifier,

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -181,8 +181,10 @@ function getModelDependencies(model: Model): Set<string> {
 		}
 	}
 
-	// Extract dependencies from all properties
-	for (const [_, prop] of model.properties) {
+	// Extract dependencies from all properties, including those inherited
+	// from a base model — the emitted schema inlines inherited property
+	// references too, so the topological sort must see them.
+	for (const [_, prop] of getAllProperties(model)) {
 		extractDependencies(prop.type);
 	}
 

--- a/test/example.js
+++ b/test/example.js
@@ -299,4 +299,16 @@ describe("zod schema smoke tests", () => {
 		const overridden = { ...goodDog, status: "anything" };
 		assert.throws(() => Schemas.DogSchema.parse(overridden));
 	});
+
+	it("tracks a model-typed property inherited from a base model as a dependency", () => {
+		// A successful import of the schemas module already proves the
+		// topological sort placed NestedTargetSchema before TopSubSchema
+		// (otherwise this file would fail to load with a ReferenceError).
+		const result = Schemas.TopSubSchema.parse({
+			ref: { label: "hello" },
+			ownField: "value",
+		});
+		assert.equal(result.ref.label, "hello");
+		assert.throws(() => Schemas.TopSubSchema.parse({ ownField: "value" }));
+	});
 });

--- a/test/example.js
+++ b/test/example.js
@@ -274,4 +274,29 @@ describe("zod schema smoke tests", () => {
 	it("does not emit generic template schemas", () => {
 		assert.equal("ResultListSchema" in Schemas, false);
 	});
+
+	it("emits inherited properties from a base model", () => {
+		const goodDog = {
+			animalId: "dog-1",
+			legs: 4,
+			status: "goodBoy",
+			breed: "Labrador",
+		};
+
+		// A `Dog extends Animal` schema must accept all inherited base properties.
+		const result = Schemas.DogSchema.parse(goodDog);
+		assert.equal(result.animalId, "dog-1");
+		assert.equal(result.breed, "Labrador");
+
+		// Dropping an inherited base property must fail validation, proving the
+		// inherited property survived into the generated schema.
+		const missingInherited = { status: "goodBoy", breed: "Labrador" };
+		assert.throws(() => Schemas.DogSchema.parse(missingInherited));
+
+		// The subclass override must win on a name collision: `status` is
+		// narrowed to the literal "goodBoy", so the base's plain string must
+		// be rejected.
+		const overridden = { ...goodDog, status: "anything" };
+		assert.throws(() => Schemas.DogSchema.parse(overridden));
+	});
 });

--- a/test/main.tsp
+++ b/test/main.tsp
@@ -169,3 +169,18 @@ model ReservedWords {
   "function": string;
   normalProp: string;
 }
+
+// Test base-model inheritance: a model that `extends` a base must emit ALL
+// inherited properties (base + own), with subclass properties overriding on
+// a name collision.
+model Animal {
+  animalId: string;
+  legs: int32;
+  status: string;
+}
+
+model Dog extends Animal {
+  breed: string;
+  // overrides the inherited `status` (string) with a narrower literal type
+  status: "goodBoy";
+}

--- a/test/main.tsp
+++ b/test/main.tsp
@@ -184,3 +184,26 @@ model Dog extends Animal {
   // overrides the inherited `status` (string) with a narrower literal type
   status: "goodBoy";
 }
+
+// Regression test: a model-typed property inherited from a base model must
+// still be tracked as a topological-sort dependency. `NestedBase` and
+// `NestedTarget` live in a namespace that is collected AFTER root-level
+// models, so `TopSub` (root-level, extends the namespaced base) is added to
+// the emitter's model list before `NestedTarget` is. If the dependency walk
+// only looked at `TopSub`'s own properties (missing the inherited `ref`
+// property), the topological sort would emit `TopSubSchema` before
+// `NestedTargetSchema`, producing a forward reference that throws at import
+// time.
+namespace OrderingRegression {
+  model NestedTarget {
+    label: string;
+  }
+
+  model NestedBase {
+    ref: NestedTarget;
+  }
+}
+
+model TopSub extends OrderingRegression.NestedBase {
+  ownField: string;
+}


### PR DESCRIPTION
## Summary
A model that `extends` a base only emitted its own properties; every property inherited from the base model was dropped from the generated zod schema. Collect the full property set by walking the base-model chain, base first so a subclass property overrides an inherited one of the same name.

Ported from mvhenten/typespec-zod-emitter#2 (merged on the fork, missing from this repo's history).

## Test plan
- [x] `npm test` locally (build, lint, unit tests, emit test, smoke tests)
- [x] CI (`ci` sentinel job)