### PR TITLE
fix: emit z.string().url() for url scalar (and subtypes)

### DIFF
--- a/src/emitter.test.ts
+++ b/src/emitter.test.ts
@@ -270,6 +270,31 @@ describe("emitter helpers", () => {
 		assert.equal(__test.generateScalarSchema(derivedScalar), "z.string()");
 	});
 
+	it("matches a refined scalar before walking past it to its primitive root", () => {
+		const stringScalar = { name: "string" } as unknown as Scalar;
+		const urlScalar = {
+			name: "url",
+			baseScalar: stringScalar,
+		} as unknown as Scalar;
+		assert.equal(__test.generateScalarSchema(urlScalar), "z.string().url()");
+	});
+
+	it("resolves a user-defined scalar to the nearest known ancestor", () => {
+		const stringScalar = { name: "string" } as unknown as Scalar;
+		const urlScalar = {
+			name: "url",
+			baseScalar: stringScalar,
+		} as unknown as Scalar;
+		const httpsUrlScalar = {
+			name: "httpsUrl",
+			baseScalar: urlScalar,
+		} as unknown as Scalar;
+		assert.equal(
+			__test.generateScalarSchema(httpsUrlScalar),
+			"z.string().url()",
+		);
+	});
+
 	// === generateTypeSchema: additional type kinds ===
 
 	it("generates type schema for Enum reference", () => {

--- a/src/emitter.test.ts
+++ b/src/emitter.test.ts
@@ -261,6 +261,11 @@ describe("emitter helpers", () => {
 		assert.equal(__test.generateScalarSchema(scalar), "z.unknown()");
 	});
 
+	it("does not resolve inherited Object.prototype members as a scalar mapping", () => {
+		const scalar = { name: "toString" } as unknown as Scalar;
+		assert.equal(__test.generateScalarSchema(scalar), "z.unknown()");
+	});
+
 	it("generates scalar schema following baseScalar traversal", () => {
 		const baseScalar = { name: "string" } as unknown as Scalar;
 		const derivedScalar = {

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -407,50 +407,47 @@ function generateTypeSchema(
 	}
 }
 
+const SCALAR_SCHEMA_MAP: Record<string, string> = {
+	string: "z.string()",
+	int32: "z.number()",
+	int64: "z.number()",
+	float: "z.number()",
+	float32: "z.number()",
+	float64: "z.number()",
+	decimal: "z.number()",
+	numeric: "z.number()",
+	integer: "z.number()",
+	safeint: "z.number()",
+	uint8: "z.number()",
+	uint16: "z.number()",
+	uint32: "z.number()",
+	uint64: "z.number()",
+	int8: "z.number()",
+	int16: "z.number()",
+	boolean: "z.boolean()",
+	plainDate: "z.string().date()",
+	plainTime: "z.string().time()",
+	utcDateTime: "z.string().datetime()",
+	offsetDateTime: "z.string().datetime({ offset: true })",
+	duration: "z.string()",
+	url: "z.string().url()",
+	bytes: "z.instanceof(Uint8Array)",
+};
+
 function generateScalarSchema(scalar: Scalar): string {
-	let baseScalar = scalar;
-	while (baseScalar.baseScalar) {
-		baseScalar = baseScalar.baseScalar;
+	// Walk from the current scalar UP to the root, returning the first
+	// known mapping. This matches refined scalars (e.g. `url`, which extends
+	// `string`) before they get walked past to their primitive root.
+	let current: Scalar | undefined = scalar;
+	while (current) {
+		const mapped = SCALAR_SCHEMA_MAP[current.name];
+		if (mapped) {
+			return mapped;
+		}
+		current = current.baseScalar;
 	}
 
-	switch (baseScalar.name) {
-		case "string":
-			return "z.string()";
-		case "int32":
-		case "int64":
-		case "float":
-		case "float32":
-		case "float64":
-		case "decimal":
-		case "numeric":
-		case "integer":
-		case "safeint":
-		case "uint8":
-		case "uint16":
-		case "uint32":
-		case "uint64":
-		case "int8":
-		case "int16":
-			return "z.number()";
-		case "boolean":
-			return "z.boolean()";
-		case "plainDate":
-			return "z.string().date()";
-		case "plainTime":
-			return "z.string().time()";
-		case "utcDateTime":
-			return "z.string().datetime()";
-		case "offsetDateTime":
-			return "z.string().datetime({ offset: true })";
-		case "duration":
-			return "z.string()";
-		case "url":
-			return "z.string().url()";
-		case "bytes":
-			return "z.instanceof(Uint8Array)";
-		default:
-			return "z.unknown()";
-	}
+	return "z.unknown()";
 }
 
 function generateModelTypeSchema(

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -407,32 +407,32 @@ function generateTypeSchema(
 	}
 }
 
-const SCALAR_SCHEMA_MAP: Record<string, string> = {
-	string: "z.string()",
-	int32: "z.number()",
-	int64: "z.number()",
-	float: "z.number()",
-	float32: "z.number()",
-	float64: "z.number()",
-	decimal: "z.number()",
-	numeric: "z.number()",
-	integer: "z.number()",
-	safeint: "z.number()",
-	uint8: "z.number()",
-	uint16: "z.number()",
-	uint32: "z.number()",
-	uint64: "z.number()",
-	int8: "z.number()",
-	int16: "z.number()",
-	boolean: "z.boolean()",
-	plainDate: "z.string().date()",
-	plainTime: "z.string().time()",
-	utcDateTime: "z.string().datetime()",
-	offsetDateTime: "z.string().datetime({ offset: true })",
-	duration: "z.string()",
-	url: "z.string().url()",
-	bytes: "z.instanceof(Uint8Array)",
-};
+const SCALAR_SCHEMA_MAP = new Map<string, string>([
+	["string", "z.string()"],
+	["int32", "z.number()"],
+	["int64", "z.number()"],
+	["float", "z.number()"],
+	["float32", "z.number()"],
+	["float64", "z.number()"],
+	["decimal", "z.number()"],
+	["numeric", "z.number()"],
+	["integer", "z.number()"],
+	["safeint", "z.number()"],
+	["uint8", "z.number()"],
+	["uint16", "z.number()"],
+	["uint32", "z.number()"],
+	["uint64", "z.number()"],
+	["int8", "z.number()"],
+	["int16", "z.number()"],
+	["boolean", "z.boolean()"],
+	["plainDate", "z.string().date()"],
+	["plainTime", "z.string().time()"],
+	["utcDateTime", "z.string().datetime()"],
+	["offsetDateTime", "z.string().datetime({ offset: true })"],
+	["duration", "z.string()"],
+	["url", "z.string().url()"],
+	["bytes", "z.instanceof(Uint8Array)"],
+]);
 
 function generateScalarSchema(scalar: Scalar): string {
 	// Walk from the current scalar UP to the root, returning the first
@@ -440,7 +440,7 @@ function generateScalarSchema(scalar: Scalar): string {
 	// `string`) before they get walked past to their primitive root.
 	let current: Scalar | undefined = scalar;
 	while (current) {
-		const mapped = SCALAR_SCHEMA_MAP[current.name];
+		const mapped = SCALAR_SCHEMA_MAP.get(current.name);
 		if (mapped) {
 			return mapped;
 		}

--- a/test/example.js
+++ b/test/example.js
@@ -274,4 +274,22 @@ describe("zod schema smoke tests", () => {
 	it("does not emit generic template schemas", () => {
 		assert.equal("ResultListSchema" in Schemas, false);
 	});
+
+	it("enforces URL shape for the url scalar", () => {
+		const valid = Schemas.WebsiteSchema.parse({
+			homepage: "https://example.com",
+		});
+		assert.equal(valid.homepage, "https://example.com");
+
+		assert.throws(() => Schemas.WebsiteSchema.parse({ homepage: "not-a-url" }));
+	});
+
+	it("enforces URL shape for a derived scalar that extends url", () => {
+		const valid = Schemas.SecureLinkSchema.parse({
+			target: "https://example.com/x",
+		});
+		assert.equal(valid.target, "https://example.com/x");
+
+		assert.throws(() => Schemas.SecureLinkSchema.parse({ target: "nope" }));
+	});
 });

--- a/test/main.tsp
+++ b/test/main.tsp
@@ -169,3 +169,16 @@ model ReservedWords {
   "function": string;
   normalProp: string;
 }
+
+// Test url scalar — must emit z.string().url(), not z.string()
+model Website {
+  homepage: url;
+  feed?: url;
+}
+
+// Test derived scalar that extends url — must still emit z.string().url()
+scalar httpsUrl extends url;
+
+model SecureLink {
+  target: httpsUrl;
+}


### PR DESCRIPTION
## Summary
The previous scalar dispatch walked every scalar up to its primitive root before switching on the name. As `url` extends `string`, the loop replaced `url` with `string` before reaching the switch, making `case "url"` dead code and silently downgrading url fields to plain `z.string()`.

Walk the inheritance chain from the current scalar UP, returning the first known mapping. That catches `url` at its own level, and also resolves user-defined scalars (e.g. `scalar httpsUrl extends url`) to the nearest known ancestor.

Ported from mvhenten/typespec-zod-emitter#1.

## Test plan
- [x] `npm test` locally (build, lint, unit tests, emit test, smoke tests)
- [x] CI (`ci` sentinel job)