### PR TITLE
fix: add repository field to package.json for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
 	"description": "TypeSpec emitter for Zod validators",
 	"type": "module",
 	"main": "dist/index.js",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/kattebak/typespec-zod-emitter.git"
+	},
 	"publishConfig": {
 		"access": "public"
 	},


### PR DESCRIPTION
## Summary
npm trusted publishing rejects provenance because \`package.json\` has no \`repository.url\`. Adds it so provenance validation matches the GitHub repo.

## Test plan
- \`npm run fix\` (biome check, no changes needed)