### PR TITLE
feat: emit string and numeric constraints into generated zod schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,39 @@ option turns the whole output file off.
 - `url` → `z.string().url()`
 - `bytes` → `z.instanceof(Uint8Array)`
 
+### Constraints
+
+- `@minLength` / `@maxLength` → `.min()` / `.max()`
+- `@pattern` → `.regex()`
+- `@format` → `.uuid()`, `.url()` (also `uri`), `.email()`; any other format is ignored
+- `@minValue` / `@maxValue` → `.min()` / `.max()`
+
+Constraints declared on a scalar apply to every property typed with it, and a
+property can narrow them:
+
+```typespec
+@minLength(25)
+@maxLength(25)
+scalar ShortId extends string;
+
+model Order {
+  orderId: ShortId;
+
+  @minValue(1)
+  @maxValue(5)
+  rating: int32;
+}
+```
+
+Generates:
+
+```typescript
+export const OrderSchema = z.object({
+  orderId: z.string().min(25).max(25),
+  rating: z.number().min(1).max(5),
+});
+```
+
 ### Complex Types
 
 - `Array<T>` or `T[]` → `z.array(T)`

--- a/src/emitter.test.ts
+++ b/src/emitter.test.ts
@@ -716,6 +716,97 @@ describe("emitter helpers", () => {
 		);
 	});
 
+	// === constraints ===
+
+	it("appends string constraints in a stable order", () => {
+		assert.equal(
+			__test.applyConstraints("z.string()", {
+				minLength: 2,
+				maxLength: 8,
+				pattern: "^[a-z]+$",
+				format: "email",
+			}),
+			"z.string().email().regex(/^[a-z]+$/).min(2).max(8)",
+		);
+	});
+
+	it("appends numeric constraints", () => {
+		assert.equal(
+			__test.applyConstraints("z.number()", { minValue: 1, maxValue: 5 }),
+			"z.number().min(1).max(5)",
+		);
+	});
+
+	it("does not apply length constraints to a numeric schema", () => {
+		assert.equal(
+			__test.applyConstraints("z.number()", { minLength: 3, pattern: "x" }),
+			"z.number()",
+		);
+	});
+
+	it("does not apply value constraints to a string schema", () => {
+		assert.equal(
+			__test.applyConstraints("z.string()", { minValue: 3 }),
+			"z.string()",
+		);
+	});
+
+	it("maps known formats and ignores unknown ones", () => {
+		assert.equal(
+			__test.applyConstraints("z.string()", { format: "uuid" }),
+			"z.string().uuid()",
+		);
+		assert.equal(
+			__test.applyConstraints("z.string()", { format: "uri" }),
+			"z.string().url()",
+		);
+		assert.equal(
+			__test.applyConstraints("z.string()", { format: "ipv4" }),
+			"z.string()",
+		);
+	});
+
+	it("skips a format check the base schema already carries", () => {
+		assert.equal(
+			__test.applyConstraints("z.string().url()", { format: "url" }),
+			"z.string().url()",
+		);
+	});
+
+	it("leaves schemas that take no constraints untouched", () => {
+		assert.equal(
+			__test.applyConstraints("z.instanceof(Uint8Array)", { maxLength: 4 }),
+			"z.instanceof(Uint8Array)",
+		);
+	});
+
+	it("lets a refinement override the constraints it inherits", () => {
+		assert.deepEqual(
+			__test.mergeConstraints(
+				{ minLength: 25, maxLength: 25, format: "uuid" },
+				{ maxLength: 10 },
+			),
+			{
+				minLength: 25,
+				maxLength: 10,
+				pattern: undefined,
+				format: "uuid",
+				minValue: undefined,
+				maxValue: undefined,
+			},
+		);
+	});
+
+	it("renders patterns as regex literals, escaping unescaped slashes", () => {
+		assert.equal(
+			__test.toRegexLiteral("^[A-Z]{2}-\\d{4}$"),
+			"/^[A-Z]{2}-\\d{4}$/",
+		);
+		assert.equal(__test.toRegexLiteral("a/b"), "/a\\/b/");
+		assert.equal(__test.toRegexLiteral("a\\/b"), "/a\\/b/");
+		assert.equal(__test.toRegexLiteral("a\nb"), 'new RegExp("a\\nb")');
+	});
+
 	it("generates union schema with Number and Boolean literal variants", () => {
 		const union = {
 			variants: new Map([

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -2,9 +2,16 @@ import type { EmitContext } from "@typespec/compiler";
 import {
 	type Enum,
 	emitFile,
+	getFormat,
+	getMaxLength,
+	getMaxValue,
+	getMinLength,
+	getMinValue,
+	getPattern,
 	type Model,
 	type ModelProperty,
 	type Namespace,
+	type Program,
 	resolvePath,
 	type Scalar,
 	type Type,
@@ -66,6 +73,7 @@ export async function $onEmit(context: EmitContext<ZodEmitterOptions>) {
 		packageName,
 		packageVersion,
 		modelNameMap,
+		context.program,
 	);
 
 	await emitFile(context.program, {
@@ -80,9 +88,10 @@ export async function $onEmit(context: EmitContext<ZodEmitterOptions>) {
 			: generateMiddleware(
 					context.program,
 					{
-						type: (type) => generateTypeSchema(type, modelNameMap),
+						type: (type) =>
+							generateTypeSchema(type, modelNameMap, context.program),
 						property: (property) =>
-							generatePropertySchema(property, modelNameMap),
+							generatePropertySchema(property, modelNameMap, context.program),
 						propertyName: quotePropertyName,
 						properties: getAllProperties,
 					},
@@ -288,6 +297,7 @@ function generateZodSchemas(
 	packageName?: string,
 	packageVersion?: string,
 	modelNameMap?: Map<Model, string>,
+	program?: Program,
 ): string {
 	const imports = 'import { z } from "zod";\n\n';
 
@@ -311,7 +321,7 @@ function generateZodSchemas(
 		.join("\n\n");
 
 	const modelSchemas = sortedModels
-		.map((model) => generateModelSchema(model, modelNameMap))
+		.map((model) => generateModelSchema(model, modelNameMap, program))
 		.join("\n\n");
 
 	return (
@@ -412,11 +422,12 @@ function getAllProperties(model: Model): Map<string, ModelProperty> {
 function generateModelSchema(
 	model: Model,
 	modelNameMap?: Map<Model, string>,
+	program?: Program,
 ): string {
 	const properties: string[] = [];
 
 	for (const [propName, prop] of getAllProperties(model)) {
-		const zodType = generatePropertySchema(prop, modelNameMap);
+		const zodType = generatePropertySchema(prop, modelNameMap, program);
 		const quotedName = quotePropertyName(propName);
 		properties.push(`\t${quotedName}: ${zodType}`);
 	}
@@ -430,8 +441,14 @@ function generateModelSchema(
 function generatePropertySchema(
 	prop: ModelProperty,
 	modelNameMap?: Map<Model, string>,
+	program?: Program,
 ): string {
-	let schema = generateTypeSchema(prop.type, modelNameMap);
+	// A property may narrow the constraints of its own scalar type, so the
+	// property itself is the last constraint source in the chain.
+	let schema =
+		prop.type.kind === "Scalar"
+			? generateScalarSchema(prop.type, program, prop)
+			: generateTypeSchema(prop.type, modelNameMap, program);
 
 	if (prop.optional) {
 		schema += ".optional()";
@@ -443,16 +460,17 @@ function generatePropertySchema(
 function generateTypeSchema(
 	type: Type,
 	modelNameMap?: Map<Model, string>,
+	program?: Program,
 ): string {
 	switch (type.kind) {
 		case "Scalar":
-			return generateScalarSchema(type);
+			return generateScalarSchema(type, program);
 		case "Model":
-			return generateModelTypeSchema(type, modelNameMap);
+			return generateModelTypeSchema(type, modelNameMap, program);
 		case "Enum":
 			return `${type.name}Schema`;
 		case "Union":
-			return generateUnionSchema(type, modelNameMap);
+			return generateUnionSchema(type, modelNameMap, program);
 		case "String":
 			return `z.literal("${type.value}")`;
 		case "Number":
@@ -491,7 +509,119 @@ const SCALAR_SCHEMA_MAP = new Map<string, string>([
 	["bytes", "z.instanceof(Uint8Array)"],
 ]);
 
-function generateScalarSchema(scalar: Scalar): string {
+const FORMAT_CHECK_MAP = new Map<string, string>([
+	["uuid", ".uuid()"],
+	["url", ".url()"],
+	["uri", ".url()"],
+	["email", ".email()"],
+]);
+
+interface Constraints {
+	minLength?: number;
+	maxLength?: number;
+	pattern?: string;
+	format?: string;
+	minValue?: number;
+	maxValue?: number;
+}
+
+function readConstraints(program: Program, target: Type): Constraints {
+	return {
+		minLength: getMinLength(program, target),
+		maxLength: getMaxLength(program, target),
+		pattern: getPattern(program, target),
+		format: getFormat(program, target),
+		minValue: getMinValue(program, target),
+		maxValue: getMaxValue(program, target),
+	};
+}
+
+function mergeConstraints(base: Constraints, refinement: Constraints) {
+	return {
+		minLength: refinement.minLength ?? base.minLength,
+		maxLength: refinement.maxLength ?? base.maxLength,
+		pattern: refinement.pattern ?? base.pattern,
+		format: refinement.format ?? base.format,
+		minValue: refinement.minValue ?? base.minValue,
+		maxValue: refinement.maxValue ?? base.maxValue,
+	};
+}
+
+function collectConstraints(
+	program: Program,
+	scalar: Scalar,
+	property?: ModelProperty,
+): Constraints {
+	// Root scalar first, so each refinement overrides the one it extends and
+	// the property (if any) has the final say.
+	const sources: Type[] = [];
+	for (
+		let current: Scalar | undefined = scalar;
+		current;
+		current = current.baseScalar
+	) {
+		sources.unshift(current);
+	}
+	if (property) {
+		sources.push(property);
+	}
+
+	return sources.reduce<Constraints>(
+		(merged, source) =>
+			mergeConstraints(merged, readConstraints(program, source)),
+		{},
+	);
+}
+
+function toRegexLiteral(pattern: string): string {
+	if (/[\n\r\u2028\u2029]/.test(pattern)) {
+		return `new RegExp(${JSON.stringify(pattern)})`;
+	}
+
+	const escaped = pattern.replace(/\\.|\//g, (match) =>
+		match === "/" ? "\\/" : match,
+	);
+	return `/${escaped}/`;
+}
+
+function applyConstraints(schema: string, constraints: Constraints): string {
+	const checks: string[] = [];
+
+	if (schema.startsWith("z.string()")) {
+		const formatCheck = constraints.format
+			? FORMAT_CHECK_MAP.get(constraints.format.toLowerCase())
+			: undefined;
+		if (formatCheck && !schema.includes(formatCheck)) {
+			checks.push(formatCheck);
+		}
+		if (constraints.pattern !== undefined) {
+			checks.push(`.regex(${toRegexLiteral(constraints.pattern)})`);
+		}
+		if (constraints.minLength !== undefined) {
+			checks.push(`.min(${constraints.minLength})`);
+		}
+		if (constraints.maxLength !== undefined) {
+			checks.push(`.max(${constraints.maxLength})`);
+		}
+	}
+
+	if (schema.startsWith("z.number()")) {
+		if (constraints.minValue !== undefined) {
+			checks.push(`.min(${constraints.minValue})`);
+		}
+		if (constraints.maxValue !== undefined) {
+			checks.push(`.max(${constraints.maxValue})`);
+		}
+	}
+
+	return schema + checks.join("");
+}
+
+function generateScalarSchema(
+	scalar: Scalar,
+	program?: Program,
+	property?: ModelProperty,
+): string {
 	// Walk from the current scalar UP to the root, returning the first
 	// known mapping. This matches refined scalars (e.g. `url`, which extends
 	// `string`) before they get walked past to their primitive root.
@@ -499,7 +629,13 @@ function generateScalarSchema(scalar: Scalar): string {
 	while (current) {
 		const mapped = SCALAR_SCHEMA_MAP.get(current.name);
 		if (mapped) {
-			return mapped;
+			if (!program) {
+				return mapped;
+			}
+			return applyConstraints(
+				mapped,
+				collectConstraints(program, scalar, property),
+			);
 		}
 		current = current.baseScalar;
 	}
@@ -510,22 +646,23 @@ function generateScalarSchema(scalar: Scalar): string {
 function generateModelTypeSchema(
 	model: Model,
 	modelNameMap?: Map<Model, string>,
+	program?: Program,
 ): string {
 	if (model.name === "Array" && model.indexer?.value) {
 		const elementType = model.indexer.value;
-		return `z.array(${generateTypeSchema(elementType, modelNameMap)})`;
+		return `z.array(${generateTypeSchema(elementType, modelNameMap, program)})`;
 	}
 
 	if (model.indexer && model.indexer.key.name === "string") {
 		const valueType = model.indexer.value;
-		return `z.record(z.string(), ${generateTypeSchema(valueType, modelNameMap)})`;
+		return `z.record(z.string(), ${generateTypeSchema(valueType, modelNameMap, program)})`;
 	}
 
 	// Handle anonymous object literals (inline object types)
 	if (!model.name || model.name === "" || model.name === "object") {
 		const properties: string[] = [];
 		for (const [propName, prop] of model.properties) {
-			const zodType = generatePropertySchema(prop, modelNameMap);
+			const zodType = generatePropertySchema(prop, modelNameMap, program);
 			const quotedName = quotePropertyName(propName);
 			properties.push(`${quotedName}: ${zodType}`);
 		}
@@ -545,7 +682,7 @@ function generateModelTypeSchema(
 		// Generate it inline as an anonymous object
 		const properties: string[] = [];
 		for (const [propName, prop] of model.properties) {
-			const zodType = generatePropertySchema(prop, modelNameMap);
+			const zodType = generatePropertySchema(prop, modelNameMap, program);
 			const quotedName = quotePropertyName(propName);
 			properties.push(`${quotedName}: ${zodType}`);
 		}
@@ -560,6 +697,7 @@ function generateModelTypeSchema(
 function generateUnionSchema(
 	union: Union,
 	modelNameMap?: Map<Model, string>,
+	program?: Program,
 ): string {
 	const variants = Array.from(union.variants.values());
 
@@ -568,11 +706,11 @@ function generateUnionSchema(
 	}
 
 	if (variants.length === 1) {
-		return generateTypeSchema(variants[0].type, modelNameMap);
+		return generateTypeSchema(variants[0].type, modelNameMap, program);
 	}
 
 	const schemas = variants.map((variant) =>
-		generateTypeSchema(variant.type, modelNameMap),
+		generateTypeSchema(variant.type, modelNameMap, program),
 	);
 
 	return `z.union([${schemas.join(", ")}])`;
@@ -733,6 +871,7 @@ node_modules/
 }
 
 export const __test = {
+	applyConstraints,
 	containsTemplateParameter,
 	generateEnumSchema,
 	generateModelSchema,
@@ -746,6 +885,8 @@ export const __test = {
 	getModelDependencies,
 	isTemplateDeclaration,
 	isValidJavaScriptIdentifier,
+	mergeConstraints,
 	quotePropertyName,
+	toRegexLiteral,
 	topologicalSort,
 };

--- a/test/example.js
+++ b/test/example.js
@@ -8,6 +8,17 @@ import {
 } from "../build/zod-schemas/middleware.js";
 import * as Schemas from "../build/zod-schemas/schemas.ts";
 
+const validConstrained = {
+	id: "0123456789012345678901234",
+	externalId: crypto.randomUUID(),
+	nickname: "ada",
+	reference: "AB-1234",
+	contact: "ada@example.com",
+	homepage: "https://example.com",
+	rating: 4,
+	price: 19.99,
+};
+
 describe("zod schema smoke tests", () => {
 	it("parses a valid user", () => {
 		const validUser = {
@@ -323,6 +334,93 @@ describe("zod schema smoke tests", () => {
 		assert.throws(() => Schemas.DogSchema.parse(overridden));
 	});
 
+	it("enforces scalar-level length constraints on every property using the scalar", () => {
+		const tooLong = { ...validConstrained, id: crypto.randomUUID() };
+		assert.equal(tooLong.id.length, 36);
+		assert.throws(() => Schemas.ConstrainedSchema.parse(tooLong));
+
+		assert.throws(() =>
+			Schemas.ConstrainedSchema.parse({ ...validConstrained, id: "short" }),
+		);
+		assert.equal(
+			Schemas.ConstrainedSchema.parse(validConstrained).id,
+			validConstrained.id,
+		);
+	});
+
+	it("enforces property-level length constraints", () => {
+		assert.throws(() =>
+			Schemas.ConstrainedSchema.parse({ ...validConstrained, nickname: "a" }),
+		);
+		assert.throws(() =>
+			Schemas.ConstrainedSchema.parse({
+				...validConstrained,
+				nickname: "nine char",
+			}),
+		);
+		assert.throws(() =>
+			Schemas.ConstrainedSchema.parse({ ...validConstrained, code: "toolong" }),
+		);
+	});
+
+	it("enforces the pattern as a regex", () => {
+		assert.throws(() =>
+			Schemas.ConstrainedSchema.parse({
+				...validConstrained,
+				reference: "ab-1234",
+			}),
+		);
+		assert.throws(() =>
+			Schemas.ConstrainedSchema.parse({
+				...validConstrained,
+				reference: "AB-12",
+			}),
+		);
+	});
+
+	it("maps formats to zod natives", () => {
+		assert.throws(() =>
+			Schemas.ConstrainedSchema.parse({
+				...validConstrained,
+				externalId: "not-a-uuid",
+			}),
+		);
+		assert.throws(() =>
+			Schemas.ConstrainedSchema.parse({
+				...validConstrained,
+				contact: "not-an-email",
+			}),
+		);
+		assert.throws(() =>
+			Schemas.ConstrainedSchema.parse({
+				...validConstrained,
+				homepage: "not-a-url",
+			}),
+		);
+	});
+
+	it("enforces numeric value bounds", () => {
+		assert.throws(() =>
+			Schemas.ConstrainedSchema.parse({ ...validConstrained, rating: 0 }),
+		);
+		assert.throws(() =>
+			Schemas.ConstrainedSchema.parse({ ...validConstrained, rating: 6 }),
+		);
+		assert.throws(() =>
+			Schemas.ConstrainedSchema.parse({ ...validConstrained, price: -1 }),
+		);
+	});
+
+	it("lets a property narrow the constraints of its scalar type", () => {
+		const result = Schemas.NarrowedPropertySchema.parse({ label: "abcdef" });
+		assert.equal(result.label, "abcdef");
+
+		assert.throws(() => Schemas.NarrowedPropertySchema.parse({ label: "abc" }));
+		assert.throws(() =>
+			Schemas.NarrowedPropertySchema.parse({ label: "abcdefghijk" }),
+		);
+	});
+
 	it("tracks a model-typed property inherited from a base model as a dependency", () => {
 		// A successful import of the schemas module already proves the
 		// topological sort placed NestedTargetSchema before TopSubSchema
@@ -355,7 +453,7 @@ describe("request validation middleware smoke tests", () => {
 		const update = findOperation("PATCH", `${BASE_PATH}/widgets/widget-1`);
 		const list = findOperation("get", `${BASE_PATH}/widgets?status=Active`);
 
-		assert.equal(operations.length, 6);
+		assert.equal(operations.length, 7);
 		assert.equal(create.operationId, "Widgets_create");
 		assert.equal(update.operationId, "Widgets_update");
 		assert.equal(list.operationId, "Widgets_list");
@@ -435,6 +533,35 @@ describe("request validation middleware smoke tests", () => {
 
 		assert.equal(await validationMiddleware.pre(valid), undefined);
 		await assert.rejects(() => validationMiddleware.pre(invalid), {
+			name: "RequestValidationError",
+		});
+	});
+
+	it("rejects a body that violates a constraint before the request is sent", async () => {
+		const valid = request("POST", "/widgets/constrained", validConstrained);
+		const tooLongId = request("POST", "/widgets/constrained", {
+			...validConstrained,
+			id: crypto.randomUUID(),
+		});
+		const outOfRange = request("POST", "/widgets/constrained", {
+			...validConstrained,
+			rating: 9,
+		});
+
+		assert.equal(await validationMiddleware.pre(valid), undefined);
+		await assert.rejects(
+			() => validationMiddleware.pre(tooLongId),
+			(error) => {
+				assert.equal(error.name, "RequestValidationError");
+				assert.equal(error.operationId, "Widgets_createConstrained");
+				assert.equal(
+					error.issues.some((issue) => issue.path.join(".") === "id"),
+					true,
+				);
+				return true;
+			},
+		);
+		await assert.rejects(() => validationMiddleware.pre(outOfRange), {
 			name: "RequestValidationError",
 		});
 	});

--- a/test/main.tsp
+++ b/test/main.tsp
@@ -267,4 +267,54 @@ namespace Widgets {
   @route("/products")
   @post
   op createProduct(@body product: ProductCreateParams): Product;
+
+  @route("/constrained")
+  @post
+  op createConstrained(@body payload: Constrained): Constrained;
+}
+
+// Test constraint decorators — each must reach the generated zod schema.
+// A scalar-level constraint must flow through to every property typed with
+// that scalar (the outage this guards against: a 36-char crypto.randomUUID()
+// passing a `z.string()` that should have been length-bounded to 25).
+@minLength(25)
+@maxLength(25)
+scalar ShortId extends string;
+
+@format("uuid")
+scalar Uuid extends string;
+
+model Constrained {
+  id: ShortId;
+  externalId: Uuid;
+
+  @minLength(2)
+  @maxLength(8)
+  nickname: string;
+
+  @pattern("^[A-Z]{2}-\\d{4}$")
+  reference: string;
+
+  @format("email")
+  contact: string;
+
+  @format("url")
+  homepage: string;
+
+  @minValue(1)
+  @maxValue(5)
+  rating: int32;
+
+  @minValue(0)
+  price: float64;
+
+  @maxLength(3)
+  code?: string;
+}
+
+// A property must be able to narrow the constraints of its own scalar type.
+model NarrowedProperty {
+  @minLength(4)
+  @maxLength(10)
+  label: ShortId;
 }


### PR DESCRIPTION
Emit TypeSpec's constraint decorators into the generated zod schemas, reading them through the compiler's own accessors.

Without them a field declared 25 characters wide validated as a bare `z.string()`, so an over-long id passed every client-side layer and failed only as a server-side 400.

`@minLength`/`@maxLength` become `.min()`/`.max()`, `@pattern` a `.regex()`, `@format` the matching zod native, and `@minValue`/`@maxValue` numeric bounds. Constraints declared on a scalar flow through to every property typed with it; a property may narrow them.

Closes #32