### PR TITLE
test: cover the $onEmit option branches and cap the zod peer range

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ A TypeSpec compiler emitter that generates Zod validation schemas from TypeSpec 
 ## Testing
 
 - Unit tests (`src/emitter.test.ts`, `src/middleware.test.ts`): test internal helpers via `__test` export — identifiers, enums, scalars, unions, topological sort, anonymous objects, templates, route patterns, payload visibility
+- Emitter tests (`src/onemit.test.ts`): drive `$onEmit` over in-memory specs with `createTester` from `@typespec/compiler/testing` — option branches, early returns, package scaffolding
 - Smoke tests (`test/example.js`): compile `test/main.tsp`, then import and validate the emitted Zod schemas
 - Node built-in test runner (`node:test`), assertions via `node:assert/strict`
 - No mocking frameworks; unit tests use lightweight type stubs

--- a/README.md
+++ b/README.md
@@ -16,8 +16,19 @@ A custom TypeSpec emitter that generates Zod validators for TypeSpec models usin
 ## Installation
 
 ```bash
-npm install typespec-zod-emitter zod
+npm install typespec-zod-emitter zod@^3.23.0
 ```
+
+## Zod compatibility
+
+The emitter targets **zod 3**, and both the emitter and every generated package
+declare the peer range `^3.23.0`.
+
+The generated schemas call the string format checks `.url()` and `.datetime()`,
+which zod 4 removed, and `.date()` and `.time()`, which arrived in zod 3.23. So
+the range is capped below 4 and floored at 3.23. Emitting the zod 4 spellings
+instead would break every consumer on zod 3, which is why the range moves rather
+than the output.
 
 ## Usage
 
@@ -167,7 +178,7 @@ When both `package-name` and `package-version` are provided, a complete npm pack
     "prepare": "tsc"
   },
   "peerDependencies": {
-    "zod": "^3.0.0"
+    "zod": "^3.23.0"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,11 @@
 				"@typespec/http": "^1.4.0",
 				"tsx": "^4.20.5",
 				"typescript": "^5.9.3",
-				"zod": "^3.0.0"
+				"zod": "^3.23.0"
 			},
 			"peerDependencies": {
 				"@typespec/http": "^1.4.0",
-				"zod": "^3.0.0"
+				"zod": "^3.23.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"test:emit": "tsp compile test/main.tsp --config test/tspconfig.yaml",
 		"test:package": "npm run test:emit && tsc -p build/zod-schemas",
 		"test:example": "npm run test:package && node --test test/example.js",
-		"test:unit": "node --test --import=tsx src/**/*.test.ts",
+		"test:unit": "node --test --import=tsx src/*.test.ts",
 		"prepublishOnly": "tsc"
 	},
 	"dependencies": {
@@ -42,10 +42,10 @@
 		"@typespec/http": "^1.4.0",
 		"tsx": "^4.20.5",
 		"typescript": "^5.9.3",
-		"zod": "^3.0.0"
+		"zod": "^3.23.0"
 	},
 	"peerDependencies": {
 		"@typespec/http": "^1.4.0",
-		"zod": "^3.0.0"
+		"zod": "^3.23.0"
 	}
 }

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -21,6 +21,10 @@ import { $ } from "@typespec/compiler/typekit";
 import type { ZodEmitterOptions } from "./lib.js";
 import { generateMiddleware } from "./middleware.js";
 
+// Emitted schemas call z.string().date()/.time(), added in zod 3.23, and
+// .url()/.datetime(), dropped in zod 4.
+const ZOD_PEER_RANGE = "^3.23.0";
+
 export async function $onEmit(context: EmitContext<ZodEmitterOptions>) {
 	const models: Model[] = [];
 	const enums: Enum[] = [];
@@ -117,6 +121,7 @@ export async function $onEmit(context: EmitContext<ZodEmitterOptions>) {
 		const packageJsonContent = generatePackageJson(
 			packageName,
 			packageVersion,
+			outputFile,
 			middleware ? middlewareFile : undefined,
 		);
 		await emitFile(context.program, {
@@ -727,6 +732,7 @@ function moduleSpecifier(fileName: string): string {
 function generatePackageJson(
 	packageName: string,
 	packageVersion: string,
+	outputFile: string,
 	middlewareFile?: string,
 ): string {
 	const middlewareExport = middlewareFile
@@ -738,16 +744,19 @@ function generatePackageJson(
 			}
 		: {};
 
+	const schemasTypes = `./${moduleName(outputFile)}.d.ts`;
+	const schemasDefault = moduleSpecifier(outputFile);
+
 	const packageJson = {
 		name: packageName,
 		version: packageVersion,
 		type: "module",
-		main: "./schemas.js",
-		types: "./schemas.d.ts",
+		main: schemasDefault,
+		types: schemasTypes,
 		exports: {
 			".": {
-				types: "./schemas.d.ts",
-				default: "./schemas.js",
+				types: schemasTypes,
+				default: schemasDefault,
 			},
 			...middlewareExport,
 		},
@@ -755,7 +764,7 @@ function generatePackageJson(
 			prepare: "tsc",
 		},
 		peerDependencies: {
-			zod: "^3.0.0",
+			zod: ZOD_PEER_RANGE,
 		},
 		devDependencies: {
 			typescript: "^5.0.0",
@@ -807,8 +816,12 @@ Auto-generated Zod schemas from TypeSpec definitions.
 ## Installation
 
 \`\`\`bash
-npm install ${packageName} zod
+npm install ${packageName} zod@${ZOD_PEER_RANGE}
 \`\`\`
+
+The schemas use the zod 3 string format checks \`.url()\`, \`.datetime()\`,
+\`.date()\` and \`.time()\`, so the peer range is \`${ZOD_PEER_RANGE}\`. Zod 4 is not
+supported.
 
 ## Usage
 
@@ -871,6 +884,7 @@ node_modules/
 }
 
 export const __test = {
+	ZOD_PEER_RANGE,
 	applyConstraints,
 	containsTemplateParameter,
 	generateEnumSchema,

--- a/src/onemit.test.ts
+++ b/src/onemit.test.ts
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+import type { EmitContext } from "@typespec/compiler";
+import { createTester } from "@typespec/compiler/testing";
+import { __test, $onEmit } from "./emitter.js";
+import type { ZodEmitterOptions } from "./lib.js";
+
+const packageRoot = join(import.meta.dirname, "..");
+const outputDir = "/emit";
+
+const Tester = createTester(packageRoot, { libraries: ["@typespec/http"] });
+
+async function emit(
+	code: string,
+	options: ZodEmitterOptions = {},
+): Promise<Map<string, string>> {
+	const result = await Tester.compile(code);
+
+	await $onEmit({
+		program: result.program,
+		emitterOutputDir: outputDir,
+		options,
+	} as unknown as EmitContext<ZodEmitterOptions>);
+
+	return new Map(
+		[...result.fs.fs]
+			.filter(([path]) => path.startsWith(`${outputDir}/`))
+			.map(([path, content]) => [path.slice(outputDir.length + 1), content]),
+	);
+}
+
+const petStore = `
+	import "@typespec/http";
+	using Http;
+
+	@service
+	namespace PetStore;
+
+	model Pet {
+		name: string;
+		homepage: url;
+	}
+
+	@route("/pets")
+	@post
+	op adopt(@body pet: Pet): Pet;
+`;
+
+const petStoreWithoutOperations = `
+	import "@typespec/http";
+	using Http;
+
+	@service
+	namespace PetStore;
+
+	model Pet {
+		name: string;
+	}
+`;
+
+const petStoreWithoutHttp = `
+	namespace PetStore;
+
+	model Pet {
+		name: string;
+	}
+`;
+
+const packageOptions: ZodEmitterOptions = {
+	"package-name": "@petstore/schemas",
+	"package-version": "1.2.3",
+};
+
+describe("$onEmit", () => {
+	it("emits schemas, middleware and the package scaffolding", async () => {
+		const files = await emit(petStore, packageOptions);
+
+		assert.deepEqual(
+			[...files.keys()].sort(),
+			[
+				".npmignore",
+				"README.md",
+				"middleware.ts",
+				"package.json",
+				"schemas.ts",
+				"tsconfig.json",
+			].sort(),
+		);
+	});
+
+	it("emits nothing for a spec with no models or enums", async () => {
+		const files = await emit("namespace PetStore;", packageOptions);
+
+		assert.deepEqual([...files.keys()], []);
+	});
+
+	it("emits only the schema file without a package name and version", async () => {
+		const files = await emit(petStore);
+
+		assert.deepEqual([...files.keys()].sort(), ["middleware.ts", "schemas.ts"]);
+	});
+
+	it("skips the middleware when emit-middleware is false", async () => {
+		const files = await emit(petStore, {
+			...packageOptions,
+			"emit-middleware": false,
+		});
+
+		assert.equal(files.has("middleware.ts"), false);
+
+		const manifest = JSON.parse(files.get("package.json") ?? "{}");
+		assert.deepEqual(Object.keys(manifest.exports), ["."]);
+
+		const tsconfig = JSON.parse(files.get("tsconfig.json") ?? "{}");
+		assert.deepEqual(tsconfig.include, ["schemas.ts"]);
+
+		assert.equal(files.get("README.md")?.includes("Request Validation"), false);
+	});
+
+	it("skips the middleware for a spec that never imports the http library", async () => {
+		const files = await emit(petStoreWithoutHttp, packageOptions);
+
+		assert.equal(files.has("middleware.ts"), false);
+		assert.equal(files.has("schemas.ts"), true);
+	});
+
+	it("skips the middleware for a service with no operations", async () => {
+		const files = await emit(petStoreWithoutOperations, packageOptions);
+
+		assert.equal(files.has("middleware.ts"), false);
+		assert.equal(files.has("schemas.ts"), true);
+	});
+
+	it("honours custom output-file and middleware-file names", async () => {
+		const files = await emit(petStore, {
+			...packageOptions,
+			"output-file": "validators.ts",
+			"middleware-file": "guard.ts",
+		});
+
+		assert.equal(files.has("validators.ts"), true);
+		assert.equal(files.has("schemas.ts"), false);
+		assert.equal(files.has("guard.ts"), true);
+		assert.equal(files.has("middleware.ts"), false);
+
+		assert.match(files.get("guard.ts") ?? "", /from "\.\/validators\.js"/);
+
+		const manifest = JSON.parse(files.get("package.json") ?? "{}");
+		assert.equal(manifest.main, "./validators.js");
+		assert.equal(manifest.types, "./validators.d.ts");
+		assert.deepEqual(manifest.exports, {
+			".": { types: "./validators.d.ts", default: "./validators.js" },
+			"./guard": { types: "./guard.d.ts", default: "./guard.js" },
+		});
+
+		const tsconfig = JSON.parse(files.get("tsconfig.json") ?? "{}");
+		assert.deepEqual(tsconfig.include, ["validators.ts", "guard.ts"]);
+
+		assert.match(files.get("README.md") ?? "", /@petstore\/schemas\/guard/);
+	});
+
+	it("pins the generated package to a zod 3 peer range", async () => {
+		const files = await emit(petStore, packageOptions);
+
+		assert.match(files.get("schemas.ts") ?? "", /z\.string\(\)\.url\(\)/);
+
+		const manifest = JSON.parse(files.get("package.json") ?? "{}");
+		assert.equal(manifest.peerDependencies.zod, __test.ZOD_PEER_RANGE);
+		assert.match(__test.ZOD_PEER_RANGE, /^\^3\./);
+
+		const readme = files.get("README.md") ?? "";
+		assert.ok(readme.includes(`zod@${__test.ZOD_PEER_RANGE}`));
+		assert.ok(readme.includes("Zod 4 is not"));
+	});
+
+	it("declares the same zod range for the emitter itself", async () => {
+		const manifest = JSON.parse(
+			await readFile(join(packageRoot, "package.json"), "utf8"),
+		);
+
+		assert.equal(manifest.peerDependencies.zod, __test.ZOD_PEER_RANGE);
+		assert.equal(manifest.devDependencies.zod, __test.ZOD_PEER_RANGE);
+	});
+});


### PR DESCRIPTION
$onEmit had no test. Every option branch — `emit-middleware: false`, a spec without `@typespec/http`, a service with no operations, the empty-spec early return, custom `output-file`/`middleware-file` — is now driven over an in-memory pet-store spec with `createTester`.

Two things the coverage caught. The generated `package.json` hardcoded `./schemas.js` for `main`, `types` and `exports`, so a custom `output-file` produced a manifest pointing at a file that does not exist. And the emitted schemas call `.url()`/`.datetime()`, gone in zod 4, alongside `.date()`/`.time()`, added in zod 3.23 — so the peer range moves to `^3.23.0` rather than the output moving to the zod 4 spellings, which would break every consumer on zod 3. The decision is in the README and a test holds it.

`test:unit` now globs `src/*.test.ts`, which the shell expands, instead of `src/**/*.test.ts`, which only worked because Node expanded it.

Closes #39