### PR TITLE
fix: match the most specific route, not the first

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,12 @@ export const operations: readonly OperationSchemas[] = [
 ];
 ```
 
+A matcher tolerates a base path, so several routes can match one request path.
+`findOperation` returns the most specific of them: a literal segment beats a
+parameter segment, and a longer path beats a shorter one, so
+`POST /orders/{orderId}/items` wins over `POST /items` and `POST /orders/draft`
+wins over `POST /orders/{orderId}`.
+
 Attach the middleware to the generated client and every JSON request body is
 validated before the request is sent:
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -419,6 +419,32 @@ export class RequestValidationError extends Error {
 	}
 }
 
+// A route pattern tolerates a base path, so a short route matches a longer
+// request path too: /items matches /orders/order-1/items. Matching walks the
+// most specific route first, where a literal segment beats a parameter segment
+// and a longer path beats a shorter one.
+const routes: readonly OperationSchemas[] = [...operations].sort(
+	(left, right) => compareSpecificity(left.path, right.path),
+);
+
+function pathSegments(path: string): string[] {
+	return path.split("/").filter((segment) => segment !== "");
+}
+
+function literalSegmentCount(segments: readonly string[]): number {
+	return segments.filter((segment) => !segment.includes("{")).length;
+}
+
+function compareSpecificity(left: string, right: string): number {
+	const leftSegments = pathSegments(left);
+	const rightSegments = pathSegments(right);
+
+	return (
+		literalSegmentCount(rightSegments) - literalSegmentCount(leftSegments) ||
+		rightSegments.length - leftSegments.length
+	);
+}
+
 export function findOperation(
 	method: string,
 	url: string,
@@ -426,7 +452,7 @@ export function findOperation(
 	const wanted = method.toUpperCase();
 	const pathname = pathnameOf(url);
 
-	return operations.find(
+	return routes.find(
 		(operation) =>
 			operation.method === wanted && operation.pattern.test(pathname),
 	);

--- a/test/example.js
+++ b/test/example.js
@@ -453,7 +453,7 @@ describe("request validation middleware smoke tests", () => {
 		const update = findOperation("PATCH", `${BASE_PATH}/widgets/widget-1`);
 		const list = findOperation("get", `${BASE_PATH}/widgets?status=Active`);
 
-		assert.equal(operations.length, 7);
+		assert.equal(operations.length, 11);
 		assert.equal(create.operationId, "Widgets_create");
 		assert.equal(update.operationId, "Widgets_update");
 		assert.equal(list.operationId, "Widgets_list");
@@ -585,5 +585,52 @@ describe("request validation middleware smoke tests", () => {
 			undefined,
 		);
 		await assert.rejects(() => createValidationMiddleware().pre(context));
+	});
+});
+
+describe("route specificity smoke tests", () => {
+	it("prefers a literal segment over a parameter segment", () => {
+		assert.equal(
+			findOperation("POST", `${BASE_PATH}/orders/draft`).operationId,
+			"Orders_createDraft",
+		);
+		assert.equal(
+			findOperation("POST", `${BASE_PATH}/orders/order-1`).operationId,
+			"Orders_annotate",
+		);
+	});
+
+	it("prefers the longer path when a shorter route also matches", () => {
+		assert.equal(
+			findOperation("POST", `${BASE_PATH}/orders/order-1/items`).operationId,
+			"Orders_addItem",
+		);
+		assert.equal(
+			findOperation("POST", `${BASE_PATH}/items`).operationId,
+			"Catalog_create",
+		);
+	});
+
+	it("validates the body of the route it picked", async () => {
+		const item = request("POST", "/orders/order-1/items", {
+			sku: "sku-1",
+			quantity: 2,
+		});
+		const draft = request("POST", "/orders/draft", { note: "hold until paid" });
+		const invalid = request("POST", "/orders/order-1/items", { sku: "sku-1" });
+
+		assert.equal(await validationMiddleware.pre(item), undefined);
+		assert.equal(await validationMiddleware.pre(draft), undefined);
+		await assert.rejects(
+			() => validationMiddleware.pre(invalid),
+			(error) => {
+				assert.equal(error.operationId, "Orders_addItem");
+				assert.equal(
+					error.issues.some((issue) => issue.path.join(".") === "quantity"),
+					true,
+				);
+				return true;
+			},
+		);
 	});
 });

--- a/test/main.tsp
+++ b/test/main.tsp
@@ -318,3 +318,45 @@ model NarrowedProperty {
   @maxLength(10)
   label: ShortId;
 }
+
+// Route matching must pick the most specific route, not the first that
+// matches. A pattern tolerates a base path, so `POST /items` also matches
+// `/orders/order-1/items`, and `POST /orders/{orderId}` also matches
+// `/orders/draft`. Each pair carries a different body, so picking the wrong
+// route rejects a valid request.
+model OrderItem {
+  sku: string;
+  quantity: int32;
+}
+
+model OrderDraft {
+  note: string;
+}
+
+model CatalogItem {
+  sku: string;
+  label: string;
+}
+
+@service(#{ title: "Catalog Service" })
+@route("/items")
+namespace Catalog {
+  @post
+  op create(@body item: CatalogItem): CatalogItem;
+}
+
+@service(#{ title: "Order Service" })
+@route("/orders")
+namespace Orders {
+  @route("/{orderId}/items")
+  @post
+  op addItem(@path orderId: string, @body item: OrderItem): OrderItem;
+
+  @route("/{orderId}")
+  @post
+  op annotate(@path orderId: string, @body item: OrderItem): OrderItem;
+
+  @route("/draft")
+  @post
+  op createDraft(@body draft: OrderDraft): OrderDraft;
+}


### PR DESCRIPTION
`findOperation` walks routes most-specific-first: a literal segment beats a parameter segment, then a longer path beats a shorter one.

A route pattern tolerates a base path, so a short route also matches a longer request path — `POST /items` matches `/orders/order-1/items` — and returning the first array entry validated the request against the wrong body schema, rejecting a valid request client-side.

The fixture gains an `/orders` and an `/items` service that collide on both shapes, declared in the order that made the old matcher pick wrong.

Fixes #36