### PR TITLE
fix: emit z.null() for a null union variant

### DIFF
--- a/src/emitter.test.ts
+++ b/src/emitter.test.ts
@@ -823,4 +823,32 @@ describe("emitter helpers", () => {
 			"z.union([z.literal(7), z.literal(false)])",
 		);
 	});
+
+	it("generates union schema with a null variant", () => {
+		const union = {
+			variants: new Map([
+				["cat", { type: { kind: "Model", name: "Cat" } as unknown as Type }],
+				[
+					"none",
+					{ type: { kind: "Intrinsic", name: "null" } as unknown as Type },
+				],
+			]),
+		} as unknown as Union;
+
+		// z.unknown() here would widen the union to accept every value.
+		assert.equal(
+			__test.generateUnionSchema(union),
+			"z.union([CatSchema, z.null()])",
+		);
+	});
+
+	it("maps intrinsic types to their zod equivalents", () => {
+		const intrinsic = (name: string) =>
+			__test.generateTypeSchema({ kind: "Intrinsic", name } as unknown as Type);
+
+		assert.equal(intrinsic("null"), "z.null()");
+		assert.equal(intrinsic("never"), "z.never()");
+		assert.equal(intrinsic("void"), "z.void()");
+		assert.equal(intrinsic("unknown"), "z.unknown()");
+	});
 });

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -482,10 +482,20 @@ function generateTypeSchema(
 			return `z.literal(${type.value})`;
 		case "Boolean":
 			return `z.literal(${type.value})`;
+		case "Intrinsic":
+			return INTRINSIC_SCHEMA_MAP.get(type.name) ?? "z.unknown()";
 		default:
 			return "z.unknown()";
 	}
 }
+
+// Without these, a `null` variant falls through to z.unknown() and the union
+// it sits in accepts every value.
+const INTRINSIC_SCHEMA_MAP = new Map<string, string>([
+	["null", "z.null()"],
+	["never", "z.never()"],
+	["void", "z.void()"],
+]);
 
 const SCALAR_SCHEMA_MAP = new Map<string, string>([
 	["string", "z.string()"],

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -2,7 +2,15 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import type { Model, ModelProperty, Program, Type } from "@typespec/compiler";
-import { type HttpOperation, Visibility } from "@typespec/http";
+import { createTestHost } from "@typespec/compiler/testing";
+import {
+	createMetadataInfo,
+	getAllHttpServices,
+	type HttpOperation,
+	resolveRequestVisibility,
+	Visibility,
+} from "@typespec/http";
+import { HttpTestLibrary } from "@typespec/http/testing";
 import { __test, isHttpEnabled } from "./middleware.js";
 
 const codegen = {
@@ -196,6 +204,212 @@ describe("middleware helpers", () => {
 		assert.equal(
 			__test.generateHeader("my-api", "1.0.0"),
 			"/**\n * Package: my-api\n * Version: 1.0.0\n */\n",
+		);
+	});
+});
+
+async function compile(source: string): Promise<Program> {
+	const host = await createTestHost({ libraries: [HttpTestLibrary] });
+	host.addTypeSpecFile(
+		"main.tsp",
+		`import "@typespec/http";\nusing Http;\n${source}`,
+	);
+	await host.compile("main.tsp");
+	return host.program;
+}
+
+function requestVisibilities(program: Program): Map<string, Visibility> {
+	const [services] = getAllHttpServices(program);
+
+	return new Map(
+		services
+			.flatMap((service) => service.operations)
+			.map((operation) => [
+				operation.operation.name,
+				resolveRequestVisibility(program, operation.operation, operation.verb),
+			]),
+	);
+}
+
+function payloadContextFor(program: Program) {
+	return {
+		codegen,
+		metadata: createMetadataInfo(program),
+		identical: new Map(),
+		visiting: new Set(),
+	};
+}
+
+function bodyTypes(program: Program): Map<string, Type> {
+	const [services] = getAllHttpServices(program);
+
+	return new Map(
+		services
+			.flatMap((service) => service.operations)
+			.flatMap((operation) => {
+				const body = operation.parameters.body;
+				return body?.bodyKind === "single"
+					? [[operation.operation.name, body.type] as const]
+					: [];
+			}),
+	);
+}
+
+function bodySchemas(program: Program): Map<string, string> {
+	const [services] = getAllHttpServices(program);
+	const context = payloadContextFor(program);
+
+	const entries = services
+		.flatMap((service) => service.operations)
+		.flatMap((operation) => {
+			const body = operation.parameters.body;
+			if (!body || body.bodyKind !== "single") {
+				return [];
+			}
+			const visibility = resolveRequestVisibility(
+				program,
+				operation.operation,
+				operation.verb,
+			);
+			return [
+				[
+					operation.operation.name,
+					__test.payloadSchema(body.type, visibility, context, body.isExplicit),
+				] as const,
+			];
+		});
+
+	return new Map(entries);
+}
+
+const KENNEL_SERVICE = `
+model Kennel {
+  @visibility(Lifecycle.Read)
+  kennelId: string;
+
+  @visibility(Lifecycle.Create)
+  registrationCode: string;
+
+  @visibility(Lifecycle.Update)
+  supersedesKennelId: string;
+
+  name: string;
+}
+
+@service
+@route("/kennels")
+namespace Kennels {
+  @post
+  op create(@body kennel: Kennel): Kennel;
+
+  @route("/{kennelId}")
+  @put
+  op replace(@path kennelId: string, @body kennel: Kennel): Kennel;
+
+  @route("/{kennelId}")
+  @patch
+  op update(@path kennelId: string, @body kennel: Kennel): Kennel;
+}
+`;
+
+describe("payload visibility against compiler metadata", () => {
+	it("resolves the verb visibilities the payload walk is driven by", async () => {
+		const visibilities = requestVisibilities(await compile(KENNEL_SERVICE));
+
+		assert.equal(visibilities.get("create"), Visibility.Create);
+		assert.equal(visibilities.get("update"), Visibility.Update);
+		assert.equal(
+			visibilities.get("replace"),
+			Visibility.Create | Visibility.Update,
+		);
+	});
+
+	it("keeps create-only and update-only properties in a PUT body", async () => {
+		const bodies = bodySchemas(await compile(KENNEL_SERVICE));
+
+		assert.equal(
+			bodies.get("create"),
+			"z.object({ registrationCode: z.string(), name: z.string() })",
+		);
+		assert.equal(
+			bodies.get("update"),
+			"z.object({ supersedesKennelId: z.string(), name: z.string() })",
+		);
+		assert.equal(
+			bodies.get("replace"),
+			"z.object({ registrationCode: z.string(), supersedesKennelId: z.string(), name: z.string() })",
+		);
+	});
+
+	it("leaves a PUT body required where a merge-patch body is optional", async () => {
+		const program = await compile(`
+model Kennel {
+  name: string;
+  capacity: int32;
+}
+
+@service
+@route("/kennels")
+namespace Kennels {
+  @route("/{kennelId}")
+  @put
+  op replace(@path kennelId: string, @body kennel: Kennel): Kennel;
+}
+`);
+		const kennel = bodyTypes(program).get("replace");
+		assert.ok(kennel);
+
+		// The Patch flag is what makes a property optional; the Create|Update
+		// bitmask a PUT resolves to does not carry it.
+		assert.equal(
+			__test.payloadSchema(
+				kennel,
+				Visibility.Create | Visibility.Update,
+				payloadContextFor(program),
+			),
+			"<Kennel>",
+		);
+		assert.equal(
+			__test.payloadSchema(
+				kennel,
+				Visibility.Update | Visibility.Patch,
+				payloadContextFor(program),
+			),
+			"z.object({ name: z.string().optional(), capacity: z.string().optional() })",
+		);
+	});
+
+	it("inlines a declared union whose variants transform under visibility", async () => {
+		const bodies = bodySchemas(
+			await compile(`
+model Collar {
+  @visibility(Lifecycle.Read)
+  collarId: string;
+
+  material: string;
+}
+
+model Microchip {
+  chipId: string;
+}
+
+union PetTag {
+  collar: Collar,
+  microchip: Microchip,
+}
+
+@service
+@route("/pets")
+namespace Pets {
+  @post
+  op tag(@body tag: PetTag): void;
+}
+`),
+		);
+
+		assert.equal(
+			bodies.get("tag"),
+			"z.union([z.object({ material: z.string() }), <Microchip>])",
 		);
 	});
 });

--- a/test/example.js
+++ b/test/example.js
@@ -432,6 +432,51 @@ describe("zod schema smoke tests", () => {
 		assert.equal(result.ref.label, "hello");
 		assert.throws(() => Schemas.TopSubSchema.parse({ ownField: "value" }));
 	});
+
+	it("inlines a declared union at every reference", () => {
+		assert.equal("PetTagSchema" in Schemas, false);
+		assert.equal("FeedingScheduleSchema" in Schemas, false);
+
+		const collared = Schemas.TaggedPetSchema.parse({
+			petId: "pet-1",
+			tag: { material: "leather", sizeCm: 40 },
+			feeding: "daily",
+			spare: null,
+		});
+		assert.equal(collared.tag.material, "leather");
+		assert.equal(collared.spare, null);
+
+		const chipped = Schemas.TaggedPetSchema.parse({
+			petId: "pet-2",
+			tag: { chipId: "chip-1", registry: "eu" },
+			feeding: "weekly",
+			spare: { material: "nylon", sizeCm: 30 },
+		});
+		assert.equal(chipped.tag.chipId, "chip-1");
+		assert.equal(chipped.spare.sizeCm, 30);
+
+		assert.throws(() =>
+			Schemas.TaggedPetSchema.parse({ ...chipped, feeding: "hourly" }),
+		);
+		assert.throws(() =>
+			Schemas.TaggedPetSchema.parse({
+				...chipped,
+				tag: { material: "leather" },
+			}),
+		);
+	});
+
+	it("keeps a null union variant from widening the union", () => {
+		// A `null` variant emitted as z.unknown() would make every value valid.
+		assert.throws(() =>
+			Schemas.TaggedPetSchema.parse({
+				petId: "pet-3",
+				tag: { chipId: "chip-1", registry: "eu" },
+				feeding: "daily",
+				spare: 42,
+			}),
+		);
+	});
 });
 
 const BASE_PATH = "https://api.example.com/v1";
@@ -453,7 +498,7 @@ describe("request validation middleware smoke tests", () => {
 		const update = findOperation("PATCH", `${BASE_PATH}/widgets/widget-1`);
 		const list = findOperation("get", `${BASE_PATH}/widgets?status=Active`);
 
-		assert.equal(operations.length, 11);
+		assert.equal(operations.length, 15);
 		assert.equal(create.operationId, "Widgets_create");
 		assert.equal(update.operationId, "Widgets_update");
 		assert.equal(list.operationId, "Widgets_list");
@@ -575,6 +620,101 @@ describe("request validation middleware smoke tests", () => {
 		assert.equal(await validationMiddleware.pre(unmapped), undefined);
 		assert.equal(await validationMiddleware.pre(withoutBody), undefined);
 		assert.equal(await validationMiddleware.pre(nonJson), undefined);
+	});
+
+	it("keeps create-only and update-only properties in a PUT body", () => {
+		const create = findOperation("POST", `${BASE_PATH}/widgets/kennels`);
+		const replace = findOperation(
+			"PUT",
+			`${BASE_PATH}/widgets/kennels/kennel-1`,
+		);
+		const update = findOperation(
+			"PATCH",
+			`${BASE_PATH}/widgets/kennels/kennel-1`,
+		);
+
+		const full = {
+			kennelId: "kennel-1",
+			registrationCode: "reg-1",
+			supersedesKennelId: "kennel-0",
+			name: "Sunny Kennel",
+			capacity: 12,
+		};
+
+		assert.deepEqual(create.body.parse(full), {
+			registrationCode: "reg-1",
+			name: "Sunny Kennel",
+			capacity: 12,
+		});
+		assert.deepEqual(update.body.parse(full), {
+			supersedesKennelId: "kennel-0",
+			name: "Sunny Kennel",
+			capacity: 12,
+		});
+		assert.deepEqual(replace.body.parse(full), {
+			registrationCode: "reg-1",
+			supersedesKennelId: "kennel-0",
+			name: "Sunny Kennel",
+			capacity: 12,
+		});
+
+		// PUT resolves Create|Update, so dropping either half fails, and neither
+		// half is made optional the way a merge-patch body would be.
+		assert.throws(() =>
+			replace.body.parse({ ...full, registrationCode: undefined }),
+		);
+		assert.throws(() =>
+			replace.body.parse({ ...full, supersedesKennelId: undefined }),
+		);
+	});
+
+	it("validates a PUT body before the request is sent", async () => {
+		const valid = request("PUT", "/widgets/kennels/kennel-1", {
+			registrationCode: "reg-1",
+			supersedesKennelId: "kennel-0",
+			name: "Sunny Kennel",
+			capacity: 12,
+		});
+		const missingCreateOnly = request("PUT", "/widgets/kennels/kennel-1", {
+			supersedesKennelId: "kennel-0",
+			name: "Sunny Kennel",
+			capacity: 12,
+		});
+
+		assert.equal(await validationMiddleware.pre(valid), undefined);
+		await assert.rejects(
+			() => validationMiddleware.pre(missingCreateOnly),
+			(error) => {
+				assert.equal(error.operationId, "Widgets_replaceKennel");
+				assert.equal(
+					error.issues.some(
+						(issue) => issue.path.join(".") === "registrationCode",
+					),
+					true,
+				);
+				return true;
+			},
+		);
+	});
+
+	it("validates a body typed as a declared union", async () => {
+		const valid = request("PUT", "/widgets/pets", {
+			petId: "pet-1",
+			tag: { chipId: "chip-1", registry: "eu" },
+			feeding: "daily",
+			spare: null,
+		});
+		const invalid = request("PUT", "/widgets/pets", {
+			petId: "pet-1",
+			tag: { chipId: "chip-1", registry: "eu" },
+			feeding: "daily",
+			spare: 42,
+		});
+
+		assert.equal(await validationMiddleware.pre(valid), undefined);
+		await assert.rejects(() => validationMiddleware.pre(invalid), {
+			name: "RequestValidationError",
+		});
 	});
 
 	it("skips validation when the opt-out flag is set", async () => {

--- a/test/main.tsp
+++ b/test/main.tsp
@@ -360,3 +360,73 @@ namespace Orders {
   @post
   op createDraft(@body draft: OrderDraft): OrderDraft;
 }
+
+// A declared `union` is not emitted as a schema of its own — every reference
+// inlines the variant schemas. Model variants must still be tracked as
+// topological-sort dependencies of the model that references the union.
+model Collar {
+  material: string;
+  sizeCm: int32;
+}
+
+model Microchip {
+  chipId: string;
+  registry: string;
+}
+
+union PetTag {
+  collar: Collar,
+  microchip: Microchip,
+}
+
+union FeedingSchedule {
+  daily: "daily",
+  weekly: "weekly",
+}
+
+union OptionalCollar {
+  collar: Collar,
+  none: null,
+}
+
+model TaggedPet {
+  petId: string;
+  tag: PetTag;
+  feeding: FeedingSchedule;
+  spare: OptionalCollar;
+}
+
+// PUT resolves `Visibility.Create | Visibility.Update`, a bitmask neither POST
+// (Create) nor PATCH (Update) produces: the body keeps create-only *and*
+// update-only properties, and leaves required properties required.
+model Kennel {
+  @visibility(Lifecycle.Read)
+  kennelId: string;
+
+  @visibility(Lifecycle.Create)
+  registrationCode: string;
+
+  @visibility(Lifecycle.Update)
+  supersedesKennelId: string;
+
+  name: string;
+  capacity: int32;
+}
+
+namespace Widgets {
+  @route("/kennels")
+  @post
+  op createKennel(@body kennel: Kennel): Kennel;
+
+  @route("/kennels/{kennelId}")
+  @put
+  op replaceKennel(@path kennelId: string, @body kennel: Kennel): Kennel;
+
+  @route("/kennels/{kennelId}")
+  @patch
+  op updateKennel(@path kennelId: string, @body kennel: Kennel): Kennel;
+
+  @route("/pets")
+  @put
+  op replacePet(@body pet: TaggedPet): TaggedPet;
+}


### PR DESCRIPTION
A `null` union variant fell through to `z.unknown()`, so the union it sat in accepted every value. Intrinsic types now map to their zod equivalents.

The defect surfaced while widening the fixture, which had no PUT operation and no declared union: PUT resolves `Visibility.Create | Visibility.Update`, a bitmask no test produced.

The fixture gains a PUT body over a model with create-only and update-only properties, a declared union with model, literal and null variants, and unit tests that drive the visibility paths through real compiler metadata rather than stubs.

Refs #37